### PR TITLE
chore: Generate crate docs & push to GitHub Pages

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,10 @@ env:
   CARGO_INCREMENTAL: "0"
   RUSTC_WRAPPER: "sccache"
   SCCACHE_GHA_ENABLED: "true"
+  # Minimum supported Rust version.
   msrv: 1.66.0
+  # Nightly Rust necessary for building docs.
+  nightly: nightly-2023-09-09
 
 jobs:
   build-msrv:
@@ -59,3 +62,34 @@ jobs:
         run: cargo test -p vise-exporter --no-default-features --all-targets
       - name: Run doc tests
         run: cargo test --workspace --all-features --doc
+
+  document:
+    needs:
+      - build
+      - build-msrv
+    # if: github.event_name == 'push' && github.ref_type == 'branch' FIXME
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.nightly }}
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.3
+
+      - name: Build docs
+        run: |
+          cargo clean --doc && \
+          cargo rustdoc -p vise-macros --all-features && \
+          cargo rustdoc -p vise --all-features && \
+          cargo rustdoc -p vise-exporter --all-features -- --cfg docsrs
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: target/doc
+          single-commit: true

--- a/crates/vise-exporter/README.md
+++ b/crates/vise-exporter/README.md
@@ -4,6 +4,9 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/matter-labs/vise#license)
 ![rust 1.66+ required](https://img.shields.io/badge/rust-1.66+-blue.svg?label=Required%20Rust)
 
+**Documentation:**
+[![crate docs (main)](https://img.shields.io/badge/main-yellow.svg?label=docs)](https://matter-labs.github.io/vise/vise_exporter/)
+
 This crate provides a simple [Prometheus] metrics exporter for metrics defined
 using [`vise`]. It is based on the [`hyper`] library and supports both pull-based
 and push-based communication with Prometheus.

--- a/crates/vise-macros/README.md
+++ b/crates/vise-macros/README.md
@@ -4,6 +4,9 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/matter-labs/vise#license)
 ![rust 1.66+ required](https://img.shields.io/badge/rust-1.66+-blue.svg?label=Required%20Rust)
 
+**Documentation:**
+[![crate docs (main)](https://img.shields.io/badge/main-yellow.svg?label=docs)](https://matter-labs.github.io/vise/vise_macros/)
+
 This crate defines procedural macros for the [`vise`] library. It is re-exported in full
 from that library, so it rarely if ever needs to be used on its own.
 

--- a/crates/vise/README.md
+++ b/crates/vise/README.md
@@ -4,6 +4,9 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/matter-labs/vise#license)
 ![rust 1.66+ required](https://img.shields.io/badge/rust-1.66+-blue.svg?label=Required%20Rust)
 
+**Documentation:**
+[![crate docs (main)](https://img.shields.io/badge/main-yellow.svg?label=docs)](https://matter-labs.github.io/vise/vise/)
+
 This library provides a high-level wrapper for defining and reporting metrics in Rust libraries and applications.
 
 ## Features

--- a/crates/vise/src/lib.rs
+++ b/crates/vise/src/lib.rs
@@ -371,7 +371,7 @@ mod wrappers;
 pub use crate::{
     buckets::Buckets,
     builder::{BuildMetric, MetricBuilder},
-    collector::Collector,
+    collector::{BeforeScrapeError, Collector},
     metrics::{Global, Metrics},
     registry::{CollectToRegistry, MetricsVisitor, Registry, METRICS_REGISTRATIONS},
     wrappers::{Family, Gauge, Histogram, LabeledFamily, LatencyObserver},

--- a/crates/vise/src/registry.rs
+++ b/crates/vise/src/registry.rs
@@ -81,7 +81,7 @@ impl RegisteredDescriptors {
 /// # Collecting metrics
 ///
 /// You can include [`Metrics`] and [`Collector`]s to a registry manually using [`Self::register_metrics()`]
-/// and [`Self::register_collectors()`]. However, this can become untenable for large apps
+/// and [`Self::register_collector()`]. However, this can become untenable for large apps
 /// with a complex dependency graph. As an alternative, you may use [`register`](crate::register) attributes
 /// to mark [`Metrics`] and [`Collector`]s that should be present in the registry, and then initialize the registry
 /// with [`Self::collect()`].


### PR DESCRIPTION
# What ❔

Generate crate docs as a part of CI and pushes them to GitHub Pages.

## Why ❔

Makes crates easier to use.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] ~Tests for the changes have been added / updated.~ (not applicable)
- [ ] ~Documentation comments have been added / updated.~ (not applicable)
- [ ] ~Code has been formatted and linted using `cargo fmt` and `cargo clippy`.~ (not applicable)