### PR TITLE
fix: Do not spam error logs for push gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
 name = "elsa"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +491,15 @@ name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -811,6 +832,22 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "itertools",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
 
 [[package]]
 name = "proc-macro2"
@@ -1427,6 +1464,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-capture"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3b1b84b84d7f95504091cb9518dea662eacba7a3bc23f23e98fe5fafede344"
+dependencies = [
+ "id-arena",
+ "predicates",
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-tunnel",
+]
+
+[[package]]
 name = "tracing-core"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,6 +1509,16 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-tunnel"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507bbab1fc2c9e606543558f5656b62e8014ba7e0ffa68b9484511b6871019c5"
+dependencies = [
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1586,6 +1646,8 @@ dependencies = [
  "once_cell",
  "tokio",
  "tracing",
+ "tracing-capture",
+ "tracing-subscriber",
  "version-sync",
  "vise",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,5 +37,6 @@ syn = { version = "2.0", features = ["full"] }
 tempfile = "3.8.0"
 tokio = "1"
 tracing = "0.1.37"
+tracing-capture = "0.1.0"
 tracing-subscriber = "0.3.17"
 version-sync = "0.9.5"

--- a/crates/vise-exporter/Cargo.toml
+++ b/crates/vise-exporter/Cargo.toml
@@ -29,6 +29,8 @@ tracing.workspace = true
 doc-comment.workspace = true
 metrics.workspace = true
 tokio = { workspace = true, features = ["rt", "macros"] }
+tracing-capture.workspace = true
+tracing-subscriber.workspace = true
 version-sync.workspace = true
 
 [features]

--- a/crates/vise-exporter/src/lib.rs
+++ b/crates/vise-exporter/src/lib.rs
@@ -479,6 +479,9 @@ doc_comment::doctest!("../README.md");
 mod tests {
     use hyper::body::Bytes;
     use tokio::sync::{mpsc, Mutex};
+    use tracing::subscriber::Subscriber;
+    use tracing_capture::{CaptureLayer, SharedStorage};
+    use tracing_subscriber::layer::SubscriberExt;
 
     use std::{
         net::Ipv4Addr,
@@ -618,11 +621,20 @@ mod tests {
                     .unwrap(),
                 Self::Error => Response::builder()
                     .status(StatusCode::SERVICE_UNAVAILABLE)
-                    .body(Body::empty())
+                    .body(Body::from(b"Mistake!".as_slice()))
                     .unwrap(),
                 Self::Panic => panic!("oops"),
             }
         }
+    }
+
+    fn tracing_subscriber(storage: &SharedStorage) -> impl Subscriber {
+        tracing_subscriber::fmt()
+            .pretty()
+            .with_max_level(tracing::Level::INFO)
+            .with_test_writer()
+            .finish()
+            .with(CaptureLayer::new(storage))
     }
 
     #[tokio::test]
@@ -630,6 +642,11 @@ mod tests {
         static REQUEST_COUNTER: AtomicU32 = AtomicU32::new(0);
 
         let _guard = TEST_MUTEX.lock().await;
+        let tracing_storage = SharedStorage::default();
+        let _subscriber_guard =
+            tracing::subscriber::set_default(tracing_subscriber(&tracing_storage));
+        // ^ **NB.** `set_default()` only works because tests use a single-threaded Tokio runtime
+
         let bind_address: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
         let (req_sender, mut req_receiver) = mpsc::unbounded_channel();
 
@@ -673,5 +690,33 @@ mod tests {
             );
             assert_scraped_payload_is_valid(&request_body);
         }
+
+        assert_logs(&tracing_storage.lock());
+    }
+
+    fn assert_logs(tracing_storage: &tracing_capture::Storage) {
+        let warnings = tracing_storage.all_events().filter(|event| {
+            event.metadata().target() == env!("CARGO_CRATE_NAME")
+                && *event.metadata().level() <= tracing::Level::WARN
+        });
+        let warnings: Vec<_> = warnings.collect();
+        // Check that we don't spam the error messages.
+        assert_eq!(warnings.len(), 1);
+
+        // Check warning contents. We should log the first encountered error (i.e., "Service unavailable").
+        let warning: &tracing_capture::CapturedEvent = &warnings[0];
+        assert!(warning
+            .message()
+            .unwrap()
+            .contains("Error pushing metrics to Prometheus push gateway"));
+        assert_eq!(
+            warning["status"].as_debug_str().unwrap(),
+            StatusCode::SERVICE_UNAVAILABLE.to_string()
+        );
+        assert_eq!(warning["body"].as_debug_str().unwrap(), "Mistake!");
+        assert!(warning["endpoint"]
+            .as_debug_str()
+            .unwrap()
+            .starts_with("http://127.0.0.1:"));
     }
 }


### PR DESCRIPTION
# What ❔

Do not spam `ERROR` / `WARN` messages when exporting metrics to the push gateway. Instead, log these messages at most once per minute. Also, log the gateway endpoint for all these messages.

## Why ❔

- Log spam is self-evidently bad.
- Having the gateway endpoint available allows to investigate error causes faster.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] ~Documentation comments have been added / updated.~ *not applicable*
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.

closes #14