### PR TITLE
fix: Validate generics for derive macros

### DIFF
--- a/crates/vise-macros/src/labels.rs
+++ b/crates/vise-macros/src/labels.rs
@@ -2,13 +2,11 @@
 
 use proc_macro::TokenStream;
 use quote::{quote, quote_spanned};
-use syn::{
-    Attribute, Data, DeriveInput, Field, Fields, Generics, Ident, LitStr, Path, PathArguments, Type,
-};
+use syn::{Attribute, Data, DeriveInput, Field, Fields, Ident, LitStr, Path, PathArguments, Type};
 
 use std::{collections::HashSet, fmt};
 
-use crate::utils::{metrics_attribute, ParseAttribute};
+use crate::utils::{ensure_no_generics, metrics_attribute, ParseAttribute};
 
 #[derive(Debug, Clone, Copy)]
 #[allow(clippy::enum_variant_names)]
@@ -200,7 +198,7 @@ impl EncodeLabelValueImpl {
     }
 
     fn parse_attrs(raw: &DeriveInput, derived_macro: &str) -> syn::Result<EncodeLabelAttrs> {
-        Self::ensure_no_generics(&raw.generics, derived_macro)?;
+        ensure_no_generics(&raw.generics, derived_macro)?;
 
         let attrs: EncodeLabelAttrs = metrics_attribute(&raw.attrs)?;
         if let Some(format) = &attrs.format {
@@ -210,15 +208,6 @@ impl EncodeLabelValueImpl {
             }
         }
         Ok(attrs)
-    }
-
-    fn ensure_no_generics(generics: &Generics, derived_macro: &str) -> syn::Result<()> {
-        if generics.params.is_empty() {
-            Ok(())
-        } else {
-            let message = format!("Generics are not supported for `derive({derived_macro})` macro");
-            Err(syn::Error::new_spanned(generics, message))
-        }
     }
 
     fn extract_enum_variants(raw: &DeriveInput, case: RenameRule) -> syn::Result<Vec<EnumVariant>> {

--- a/crates/vise-macros/src/utils.rs
+++ b/crates/vise-macros/src/utils.rs
@@ -1,6 +1,6 @@
 //! Utils shared among multiple derive macros.
 
-use syn::Attribute;
+use syn::{Attribute, Generics};
 
 pub(crate) trait ParseAttribute: Sized {
     fn parse(raw: &Attribute) -> syn::Result<Self>;
@@ -14,4 +14,13 @@ where
         .iter()
         .find(|attr| attr.meta.path().is_ident("metrics"));
     attrs.map_or_else(|| Ok(T::default()), T::parse)
+}
+
+pub(crate) fn ensure_no_generics(generics: &Generics, derived_macro: &str) -> syn::Result<()> {
+    if generics.params.is_empty() {
+        Ok(())
+    } else {
+        let message = format!("Generics are not supported for `derive({derived_macro})` macro");
+        Err(syn::Error::new_spanned(generics, message))
+    }
 }

--- a/crates/vise/src/lib.rs
+++ b/crates/vise/src/lib.rs
@@ -124,6 +124,7 @@ pub use prometheus_client::{metrics::counter::Counter, registry::Unit};
 
 /// Derives the [`EncodeLabelValue`] trait for a type, which encodes a metric label value.
 ///
+/// The type for which the trait is derived must not have generics (lifetimes, type params or const params).
 /// The macro can be configured using `#[metrics()]` attributes.
 ///
 /// # Container attributes
@@ -171,7 +172,7 @@ pub use prometheus_client::{metrics::counter::Counter, registry::Unit};
 ///
 /// # Examples
 ///
-///  ## Default format
+/// ## Default format
 ///
 /// Label value using the default `Display` formatting; note that `Display` itself is derived.
 ///
@@ -213,6 +214,7 @@ pub use vise_macros::EncodeLabelValue;
 
 /// Derives the [`EncodeLabelSet`] trait for a type, which encodes a set of metric labels.
 ///
+/// The type for which the trait is derived must not have generics (lifetimes, type params or const params).
 /// The macro can be configured using `#[metrics()]` attributes.
 ///
 /// # Container attributes
@@ -272,8 +274,9 @@ pub use vise_macros::EncodeLabelSet;
 
 /// Derives the [`Metrics`](trait@Metrics) trait for a type.
 ///
-/// This macro must be placed on a struct with named fields. Each field will be registered as metric
-/// or a family of metrics. The macro can be configured using `#[metrics()]` attributes.
+/// This macro must be placed on a struct with named fields and with no generics (lifetimes, type params
+/// or const params). Each field will be registered as metric or a family of metrics.
+/// The macro can be configured using `#[metrics()]` attributes.
 ///
 /// # Container attributes
 ///

--- a/crates/vise/tests/ui/labels/unsupported_generics.rs
+++ b/crates/vise/tests/ui/labels/unsupported_generics.rs
@@ -1,0 +1,18 @@
+use vise::EncodeLabelValue;
+
+#[derive(Debug, EncodeLabelValue)]
+struct UnsupportedLifetime<'a> {
+    label: &'a str,
+}
+
+#[derive(Debug, EncodeLabelValue)]
+struct UnsupportedConstParam<const N: usize> {
+    labels: [&'static str; N],
+}
+
+#[derive(Debug, EncodeLabelValue)]
+struct UnsupportedTypeParam<T> {
+    counter: T,
+}
+
+fn main() {}

--- a/crates/vise/tests/ui/labels/unsupported_generics.stderr
+++ b/crates/vise/tests/ui/labels/unsupported_generics.stderr
@@ -1,0 +1,17 @@
+error: Generics are not supported for `derive(EncodeLabelValue)` macro
+ --> tests/ui/labels/unsupported_generics.rs:4:27
+  |
+4 | struct UnsupportedLifetime<'a> {
+  |                           ^^^^
+
+error: Generics are not supported for `derive(EncodeLabelValue)` macro
+ --> tests/ui/labels/unsupported_generics.rs:9:29
+  |
+9 | struct UnsupportedConstParam<const N: usize> {
+  |                             ^^^^^^^^^^^^^^^^
+
+error: Generics are not supported for `derive(EncodeLabelValue)` macro
+  --> tests/ui/labels/unsupported_generics.rs:14:28
+   |
+14 | struct UnsupportedTypeParam<T> {
+   |                            ^^^

--- a/crates/vise/tests/ui/labels/unsupported_generics_for_set.rs
+++ b/crates/vise/tests/ui/labels/unsupported_generics_for_set.rs
@@ -1,0 +1,18 @@
+use vise::EncodeLabelSet;
+
+#[derive(Debug, EncodeLabelSet)]
+struct UnsupportedLifetime<'a> {
+    label: &'a str,
+}
+
+#[derive(Debug, EncodeLabelSet)]
+struct UnsupportedConstParam<const N: usize> {
+    labels: [&'static str; N],
+}
+
+#[derive(Debug, EncodeLabelSet)]
+struct UnsupportedTypeParam<T> {
+    counter: T,
+}
+
+fn main() {}

--- a/crates/vise/tests/ui/labels/unsupported_generics_for_set.stderr
+++ b/crates/vise/tests/ui/labels/unsupported_generics_for_set.stderr
@@ -1,0 +1,17 @@
+error: Generics are not supported for `derive(EncodeLabelSet)` macro
+ --> tests/ui/labels/unsupported_generics_for_set.rs:4:27
+  |
+4 | struct UnsupportedLifetime<'a> {
+  |                           ^^^^
+
+error: Generics are not supported for `derive(EncodeLabelSet)` macro
+ --> tests/ui/labels/unsupported_generics_for_set.rs:9:29
+  |
+9 | struct UnsupportedConstParam<const N: usize> {
+  |                             ^^^^^^^^^^^^^^^^
+
+error: Generics are not supported for `derive(EncodeLabelSet)` macro
+  --> tests/ui/labels/unsupported_generics_for_set.rs:14:28
+   |
+14 | struct UnsupportedTypeParam<T> {
+   |                            ^^^

--- a/crates/vise/tests/ui/metrics/unsupported_generics.rs
+++ b/crates/vise/tests/ui/metrics/unsupported_generics.rs
@@ -1,0 +1,18 @@
+use vise::Metrics;
+
+#[derive(Debug, Metrics)]
+struct UnsupportedLifetime<'a> {
+    label: &'a str,
+}
+
+#[derive(Debug, Metrics)]
+struct UnsupportedConstParam<const N: usize> {
+    labels: [&'static str; N],
+}
+
+#[derive(Debug, Metrics)]
+struct UnsupportedTypeParam<T> {
+    counter: T,
+}
+
+fn main() {}

--- a/crates/vise/tests/ui/metrics/unsupported_generics.stderr
+++ b/crates/vise/tests/ui/metrics/unsupported_generics.stderr
@@ -1,0 +1,17 @@
+error: Generics are not supported for `derive(Metrics)` macro
+ --> tests/ui/metrics/unsupported_generics.rs:4:27
+  |
+4 | struct UnsupportedLifetime<'a> {
+  |                           ^^^^
+
+error: Generics are not supported for `derive(Metrics)` macro
+ --> tests/ui/metrics/unsupported_generics.rs:9:29
+  |
+9 | struct UnsupportedConstParam<const N: usize> {
+  |                             ^^^^^^^^^^^^^^^^
+
+error: Generics are not supported for `derive(Metrics)` macro
+  --> tests/ui/metrics/unsupported_generics.rs:14:28
+   |
+14 | struct UnsupportedTypeParam<T> {
+   |                            ^^^


### PR DESCRIPTION
# What ❔

Checks that derive inputs don't contain generics when deriving `Metrics`, `EncodeLabelValue` and `EncodeLabelSet` macros.

## Why ❔

Makes compilation errors more straightforward to interpret.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.