### PR TITLE
fix: Wrap potentially blocking code in exporter

### DIFF
--- a/crates/vise-exporter/src/exporter/tests.rs
+++ b/crates/vise-exporter/src/exporter/tests.rs
@@ -55,7 +55,7 @@ async fn legacy_and_modern_metrics_can_coexist() {
     let exporter = exporter.with_legacy_exporter(init_legacy_exporter);
     report_metrics();
 
-    let response = exporter.inner.render();
+    let response = exporter.inner.render().await;
     let response = body::to_bytes(response.into_body()).await;
     let response = response.expect("failed decoding response");
     assert_scraped_payload_is_valid(&response);


### PR DESCRIPTION
# What ❔

Wraps potentially blocking metrics collection in `tokio::task::spawn_blocking`.

## Why ❔

- We already have some blocking I/O used in metric collectors (e.g., RocksDB metrics).
- Some new metrics (e.g., table sizes for Postgres) would use non-blocking I/O, which could be converted into blocking calls using `Handle::block_on()`. Without this wrapper, they run into the issue of calling it in a non-blocking context.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.