### PR TITLE
feat: Support info metrics

### DIFF
--- a/crates/vise/README.md
+++ b/crates/vise/README.md
@@ -32,6 +32,10 @@ Prometheus and compatible systems supports 3 main [metric types](https://prometh
 Metrics of all types can be supplied with _labels_. Each set of labels defines a separate metric. Thus, label space
 should be reasonably small.
 
+Besides these main types, Prometheus and this library support an additional **info** metric type. It should be used to observe
+values that do not change during the program lifetime (component configurations, metadata like app version / git commit, etc.).
+Values for this metric type are encoded as labels. Conceptually, an info metric is similar to a gauge with a constant value 1.
+
 ## Usage
 
 Add this to your Crate.toml:
@@ -104,7 +108,7 @@ _See also: [Prometheus guidelines](https://prometheus.io/docs/practices/naming/)
   Prefixes should be separated by a single `_` char.
 - Metrics with a unit should have a corresponding suffix (e.g., `_seconds`). This suffix is automatically added to the
   metric name if you specify its unit; you **must not** specify it manually.
-- Label names should not repeat the metric name and should not include units.
+- Label names should not repeat the metric name.
 - Label values for each label should have reasonably low cardinality.
 - If a label value encodes to a string (as opposed to an integer, integer range etc.), it should use snake_case.
 - Metrics in a `Family` should have uniform meaning. If a `Family` can be documented without going into label specifics,

--- a/crates/vise/src/builder.rs
+++ b/crates/vise/src/builder.rs
@@ -1,5 +1,5 @@
 use prometheus_client::{
-    encoding::EncodeMetric,
+    encoding::{EncodeLabelSet, EncodeMetric},
     metrics::{counter::Counter, TypedMetric},
 };
 
@@ -7,7 +7,7 @@ use std::hash::Hash;
 
 use crate::{
     traits::{GaugeValue, HistogramValue},
-    wrappers::{Family, Gauge, Histogram},
+    wrappers::{Family, Gauge, Histogram, Info},
     Buckets,
 };
 
@@ -83,6 +83,14 @@ impl<V: HistogramValue> BuildMetric for Histogram<V> {
 
     fn build(builder: Self::Builder) -> Self {
         Histogram::new(builder.buckets)
+    }
+}
+
+impl<S: 'static + EncodeLabelSet> BuildMetric for Info<S> {
+    type Builder = MetricBuilder;
+
+    fn build(_builder: Self::Builder) -> Self {
+        Self::default()
     }
 }
 

--- a/crates/vise/src/lib.rs
+++ b/crates/vise/src/lib.rs
@@ -384,7 +384,7 @@ pub use crate::{
         CollectToRegistry, MetricsCollection, MetricsVisitor, RegisteredDescriptors, Registry,
         METRICS_REGISTRATIONS,
     },
-    wrappers::{Family, Gauge, GaugeGuard, Histogram, LabeledFamily, LatencyObserver},
+    wrappers::{Family, Gauge, GaugeGuard, Histogram, Info, LabeledFamily, LatencyObserver},
 };
 
 #[cfg(doctest)]

--- a/crates/vise/src/lib.rs
+++ b/crates/vise/src/lib.rs
@@ -243,6 +243,13 @@ pub use vise_macros::EncodeLabelValue;
 ///
 /// [`EncodeLabelSet`]: trait@prometheus_client::encoding::EncodeLabelSet
 ///
+/// ## `unit`
+///
+/// **Type:** expression evaluating to [`Unit`]
+///
+/// Specifies unit of measurement for a label. The unit will be added to the label name as a suffix
+/// (e.g., `timeout_seconds` if placed on a field named `timeout`). This is mostly useful for [`Info`] metrics.
+///
 /// # Examples
 ///
 /// ## Set with a single label
@@ -269,6 +276,33 @@ pub use vise_macros::EncodeLabelValue;
 ///     /// Numeric label.
 ///     num: u8,
 /// }
+/// ```
+///
+/// ## Set for info metric
+///
+/// ```
+/// use vise::{EncodeLabelSet, DurationAsSecs, Unit};
+/// use std::time::Duration;
+///
+/// #[derive(Debug, EncodeLabelSet)]
+/// struct InfoLabels {
+///     /// Simple label.
+///     version: &'static str,
+///     /// Label with a unit.
+///     #[metrics(unit = Unit::Seconds)]
+///     request_timeout: DurationAsSecs,
+///     /// Another label with a unit.
+///     #[metrics(unit = Unit::Bytes)]
+///     buffer_capacity: u64,
+/// }
+///
+/// let labels = InfoLabels {
+///     version: "0.1.0",
+///     request_timeout: Duration::from_millis(100).into(),
+///     buffer_capacity: 1_024,
+/// };
+/// // will be exported as the following labels:
+/// // { version="0.1.0", request_timeout_seconds="0.1", buffer_capacity="1024" }
 /// ```
 pub use vise_macros::EncodeLabelSet;
 
@@ -386,7 +420,7 @@ pub use crate::{
     },
     wrappers::{
         Family, Gauge, GaugeGuard, Histogram, Info, LabelWithUnit, LabeledFamily, LatencyObserver,
-        SetInfoError,
+        SetInfoError, DurationAsSecs,
     },
 };
 

--- a/crates/vise/src/lib.rs
+++ b/crates/vise/src/lib.rs
@@ -384,7 +384,10 @@ pub use crate::{
         CollectToRegistry, MetricsCollection, MetricsVisitor, RegisteredDescriptors, Registry,
         METRICS_REGISTRATIONS,
     },
-    wrappers::{Family, Gauge, GaugeGuard, Histogram, Info, LabeledFamily, LatencyObserver},
+    wrappers::{
+        Family, Gauge, GaugeGuard, Histogram, Info, LabelWithUnit, LabeledFamily, LatencyObserver,
+        SetInfoError,
+    },
 };
 
 #[cfg(doctest)]

--- a/crates/vise/src/registry.rs
+++ b/crates/vise/src/registry.rs
@@ -265,8 +265,11 @@ impl Registry {
     pub fn encode<W: fmt::Write>(&self, writer: &mut W, format: Format) -> fmt::Result {
         match format {
             Format::Prometheus | Format::OpenMetricsForPrometheus => {
-                let remove_eof_terminator = matches!(format, Format::Prometheus);
-                let mut wrapper = PrometheusWrapper::new(writer, remove_eof_terminator);
+                let mut wrapper = PrometheusWrapper::new(writer);
+                if matches!(format, Format::Prometheus) {
+                    wrapper.remove_eof_terminator();
+                    wrapper.translate_info_metrics_type();
+                }
                 text::encode(&mut wrapper, &self.inner)?;
                 wrapper.flush()
             }


### PR DESCRIPTION
# What ❔

Adds support of [the info metric type](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#info) and adjacent helpers (e.g., units for labels and `DurationAsSecs` wrapper).

## Why ❔

Info metrics is the idiomatic way to expose information not changed during the program runtime (version / git commit, component configs etc.).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.