### PR TITLE
chore: Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
-## 0.1.1 - 2024-08-07
+## 0.2.0 - 2024-08-07
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## 0.1.1 - 2024-08-07
+
+### Changed
+
+- Bump minimum supported Rust version to 1.70 (#26).
+
+### Fixed
+
+- Use [`ctor`](https://crates.io/crates/ctor) to handle metrics registration instead of [`linkme`](https://crates.io/crates/linkme).
+  `linkme` requires linker configuration on recent nightly Rust versions, which degrades DevEx. (#26)
+
+## 0.1.0 - 2024-07-05
+
+The initial release of `vise`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,7 +1739,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vise"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_matches",
  "compile-fmt",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "vise-e2e-tests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "vise-exporter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "doc-comment",
  "hyper 0.14.30",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "vise-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.70.0"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]

--- a/crates/vise-exporter/CHANGELOG.md
+++ b/crates/vise-exporter/CHANGELOG.md
@@ -1,0 +1,1 @@
+../../CHANGELOG.md

--- a/crates/vise-exporter/Cargo.toml
+++ b/crates/vise-exporter/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-vise = { version = "0.1.0", path = "../vise" }
+vise = { version = "0.2.0", path = "../vise" }
 
 hyper.workspace = true
 metrics-exporter-prometheus = { workspace = true, optional = true }

--- a/crates/vise-exporter/README.md
+++ b/crates/vise-exporter/README.md
@@ -17,7 +17,7 @@ Add this to your Crate.toml:
 
 ```toml
 [dependencies]
-vise-exporter = "0.1.0"
+vise-exporter = "0.2.0"
 ```
 
 An exporter can be initialized from a metrics `Registry`:

--- a/crates/vise-exporter/src/lib.rs
+++ b/crates/vise-exporter/src/lib.rs
@@ -52,7 +52,7 @@
 //! ```
 
 // Documentation settings.
-#![doc(html_root_url = "https://docs.rs/vise-exporter/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/vise-exporter/0.2.0")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 // Linter settings.
 #![warn(missing_debug_implementations, missing_docs, bare_trait_objects)]

--- a/crates/vise-macros/CHANGELOG.md
+++ b/crates/vise-macros/CHANGELOG.md
@@ -1,0 +1,1 @@
+../../CHANGELOG.md

--- a/crates/vise-macros/src/lib.rs
+++ b/crates/vise-macros/src/lib.rs
@@ -6,7 +6,7 @@
 //! [`vise`]: https://docs.rs/vise/
 
 // Documentation settings.
-#![doc(html_root_url = "https://docs.rs/vise-macros/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/vise-macros/0.2.0")]
 // General settings.
 #![recursion_limit = "128"]
 // Linter settings.

--- a/crates/vise/CHANGELOG.md
+++ b/crates/vise/CHANGELOG.md
@@ -1,0 +1,1 @@
+../../CHANGELOG.md

--- a/crates/vise/Cargo.toml
+++ b/crates/vise/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-vise-macros = { version = "0.1.0", path = "../vise-macros" }
+vise-macros = { version = "=0.2.0", path = "../vise-macros" }
 
 compile-fmt.workspace = true
 elsa.workspace = true

--- a/crates/vise/README.md
+++ b/crates/vise/README.md
@@ -42,7 +42,7 @@ Add this to your Crate.toml:
 
 ```toml
 [dependencies]
-vise = "0.1.0"
+vise = "0.2.0"
 ```
 
 ### Defining and reporting metrics

--- a/crates/vise/src/lib.rs
+++ b/crates/vise/src/lib.rs
@@ -114,7 +114,7 @@
 //! ```
 
 // Documentation settings.
-#![doc(html_root_url = "https://docs.rs/vise/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/vise/0.2.0")]
 // Linter settings.
 #![warn(missing_debug_implementations, missing_docs, bare_trait_objects)]
 #![warn(clippy::all, clippy::pedantic)]


### PR DESCRIPTION
# What ❔

Bumps the crates version to 0.2.0 and adds a changelog.

## Why ❔

Prepares the crates for the next release. A breaking release is chosen so that vise 0.1.0 doesn't break; it has a caret requirement on vise-macros ^0.1.0, and there's a breaking change on non-public code used by the macros.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).