### PR TITLE
feat!: Share common labels among metrics

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,6 +1,6 @@
 # Minimum supported Rust version. Should be consistent with CI and mentions
 # in crate READMEs.
-msrv = "1.70"
+msrv = "1.79"
 
 # Identifiers that should not trigger the `doc_markdown` lint.
 doc-valid-idents = ["OpenMetrics", ".."]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ env:
   RUSTC_WRAPPER: "sccache"
   SCCACHE_GHA_ENABLED: "true"
   # Minimum supported Rust version.
-  msrv: 1.70.0
+  msrv: 1.79.0
   # Nightly Rust necessary for building docs.
   nightly: nightly-2024-08-01
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.4
 
       - name: Format
-        run: cargo fmt --all -- --check
+        run: cargo fmt --all -- --config imports_granularity=Crate --config group_imports=StdExternalCrate --check
       - name: Clippy
         run: cargo clippy --workspace --all-features --all-targets -- -D warnings
       - name: Clippy exporter (no features)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- Allow sharing common label set among multiple metrics using an interface similar to `Family` (#30).
+
+### Changed
+
+- Bump minimum supported Rust version to 1.79 (#30).
+
 ## 0.2.0 - 2024-08-07
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 
 [[package]]
 name = "assert_matches"
@@ -52,23 +52,23 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
@@ -91,15 +91,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -109,15 +109,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "cc"
-version = "1.1.7"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -149,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossbeam-epoch"
@@ -164,15 +167,15 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "ctor"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn",
@@ -190,14 +193,25 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "0.99.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -215,24 +229,24 @@ checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "elsa"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98e71ae4df57d214182a2e5cb90230c0192c6ddfcaa05c36453d46a54713e10"
+checksum = "2343daaeabe09879d4ea058bb4f1e63da3fc07dadc6634e01bda1b3d6a9d9d2b"
 dependencies = [
  "stable_deref_trait",
 ]
 
 [[package]]
 name = "enum-as-inner"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -242,25 +256,25 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fnv"
@@ -294,30 +308,30 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -333,20 +347,32 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
@@ -365,15 +391,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -394,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -421,7 +447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -432,16 +458,16 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "httpdate"
@@ -451,9 +477,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -474,14 +500,14 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -499,7 +525,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -509,22 +535,139 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.7"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -535,12 +678,23 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -555,19 +709,19 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "itertools"
@@ -580,16 +734,17 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -601,15 +756,21 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -623,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "mach2"
@@ -701,30 +862,29 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -765,26 +925,26 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.3"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -806,15 +966,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -848,7 +1008,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -858,30 +1018,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -891,15 +1031,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "powerfmt"
@@ -928,15 +1068,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -984,7 +1124,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "memchr",
  "unicase",
 ]
@@ -1000,16 +1140,16 @@ dependencies = [
  "mach2",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1041,7 +1181,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1055,18 +1195,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1076,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1087,24 +1227,24 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -1122,12 +1262,13 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1138,55 +1279,60 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+
+[[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1201,7 +1347,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1210,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1220,24 +1366,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1246,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",
@@ -1258,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -1287,6 +1433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,15 +1455,15 @@ checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1325,9 +1477,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1336,18 +1488,39 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "target-triple"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1364,18 +1537,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1394,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1414,34 +1587,29 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.8.0"
+name = "tinystr"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
- "tinyvec_macros",
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1457,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1490,14 +1658,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.20",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -1515,7 +1683,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1524,27 +1692,27 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.18",
+ "winnow 0.7.3",
 ]
 
 [[package]]
 name = "tower"
-version = "0.4.13"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project",
  "pin-project-lite",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -1552,21 +1720,21 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -1575,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1599,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1620,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -1650,53 +1818,36 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "207aa50d36c4be8d8c6ea829478be44a372c6a77669937bb39c698e52f1491e8"
+checksum = "b812699e0c4f813b872b373a4471717d9eb550da14b311058a4d9cf4173cbca6"
 dependencies = [
  "glob",
  "serde",
  "serde_derive",
  "serde_json",
+ "target-triple",
  "termcolor",
- "toml 0.8.19",
+ "toml 0.8.20",
 ]
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1705,10 +1856,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "valuable"
-version = "0.1.0"
+name = "utf16_iter"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -1777,7 +1940,7 @@ name = "vise-exporter"
 version = "0.2.0"
 dependencies = [
  "doc-comment",
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "metrics",
  "metrics-exporter-prometheus",
  "once_cell",
@@ -1815,24 +1978,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.92"
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1841,21 +2014,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1863,9 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1876,15 +2050,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1922,12 +2099,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-registry"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1936,7 +2134,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1945,22 +2143,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1969,21 +2152,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1993,21 +2170,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2023,21 +2188,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2047,21 +2200,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2080,21 +2221,56 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
+name = "wit-bindgen-rt"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
+ "bitflags 2.8.0",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -2112,6 +2288,49 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.79.0"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 repository = "https://github.com/matter-labs/vise"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/matter-labs/vise/workflows/Rust/badge.svg?branch=main)](https://github.com/matter-labs/vise/actions)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/matter-labs/vise#license)
-![rust 1.70+ required](https://img.shields.io/badge/rust-1.70+-blue.svg?label=Required%20Rust)
+![rust 1.79+ required](https://img.shields.io/badge/rust-1.79+-blue.svg?label=Required%20Rust)
 
 This repository provides a collection of tools to define and export metrics in Rust
 libraries and applications.

--- a/crates/vise-exporter/README.md
+++ b/crates/vise-exporter/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/matter-labs/vise/workflows/Rust/badge.svg?branch=main)](https://github.com/matter-labs/vise/actions)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/matter-labs/vise#license)
-![rust 1.70+ required](https://img.shields.io/badge/rust-1.70+-blue.svg?label=Required%20Rust)
+![rust 1.79+ required](https://img.shields.io/badge/rust-1.79+-blue.svg?label=Required%20Rust)
 
 **Documentation:**
 [![crate docs (main)](https://img.shields.io/badge/main-yellow.svg?label=docs)](https://matter-labs.github.io/vise/vise_exporter/)

--- a/crates/vise-exporter/src/exporter/mod.rs
+++ b/crates/vise-exporter/src/exporter/mod.rs
@@ -1,13 +1,5 @@
 //! `MetricsExporter` and closely related types.
 
-use hyper::{
-    body, header,
-    service::{make_service_fn, service_fn},
-    Body, Client, Method, Request, Response, Server, StatusCode, Uri,
-};
-#[cfg(feature = "legacy")]
-use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
-
 use std::{
     collections::HashSet,
     fmt::{self, Write as _},
@@ -19,11 +11,20 @@ use std::{
     time::{Duration, Instant},
 };
 
+use hyper::{
+    body, header,
+    service::{make_service_fn, service_fn},
+    Body, Client, Method, Request, Response, Server, StatusCode, Uri,
+};
+#[cfg(feature = "legacy")]
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
 #[cfg(test)]
 mod tests;
 
-use crate::metrics::{Facade, EXPORTER_METRICS};
 use vise::{Format, MetricsCollection, Registry};
+
+use crate::metrics::{Facade, EXPORTER_METRICS};
 
 #[derive(Clone)]
 struct MetricsExporterInner {

--- a/crates/vise-exporter/src/exporter/tests.rs
+++ b/crates/vise-exporter/src/exporter/tests.rs
@@ -1,19 +1,19 @@
 //! Tests for metrics exporter.
 
-use hyper::body::Bytes;
-use tokio::sync::{mpsc, Mutex};
-use tracing::subscriber::Subscriber;
-use tracing_capture::{CaptureLayer, SharedStorage};
-use tracing_subscriber::layer::SubscriberExt;
-
 use std::{
     net::Ipv4Addr,
     str,
     sync::atomic::{AtomicU32, Ordering},
 };
 
-use super::*;
+use hyper::body::Bytes;
+use tokio::sync::{mpsc, Mutex};
+use tracing::subscriber::Subscriber;
+use tracing_capture::{CaptureLayer, SharedStorage};
+use tracing_subscriber::layer::SubscriberExt;
 use vise::{Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, Global, Metrics};
+
+use super::*;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(3);
 // Since all tests access global state (metrics), we shouldn't run them in parallel

--- a/crates/vise-macros/README.md
+++ b/crates/vise-macros/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/matter-labs/vise/workflows/Rust/badge.svg?branch=main)](https://github.com/matter-labs/vise/actions)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/matter-labs/vise#license)
-![rust 1.70+ required](https://img.shields.io/badge/rust-1.70+-blue.svg?label=Required%20Rust)
+![rust 1.79+ required](https://img.shields.io/badge/rust-1.79+-blue.svg?label=Required%20Rust)
 
 **Documentation:**
 [![crate docs (main)](https://img.shields.io/badge/main-yellow.svg?label=docs)](https://matter-labs.github.io/vise/vise_macros/)

--- a/crates/vise-macros/src/labels.rs
+++ b/crates/vise-macros/src/labels.rs
@@ -496,10 +496,10 @@ impl EncodeLabelSetImpl {
         let cr = self.attrs.path_to_crate(proc_macro2::Span::call_site());
         let encoding = quote!(#cr::_reexports::encoding);
         quote! {
-            impl #encoding::EncodeLabelSet for #name {
+            impl #cr::traits::EncodeLabelSet for #name {
                 fn encode(
                     &self,
-                    mut encoder: #encoding::LabelSetEncoder<'_>,
+                    encoder: &mut #encoding::LabelSetEncoder<'_>,
                 ) -> core::fmt::Result {
                     #encode_impl
                 }

--- a/crates/vise-macros/src/labels.rs
+++ b/crates/vise-macros/src/labels.rs
@@ -1,12 +1,12 @@
 //! Derivation of `EncodeLabelValue` and `EncodeLabelSet` traits.
 
+use std::{collections::HashSet, fmt};
+
 use proc_macro::TokenStream;
 use quote::{quote, quote_spanned};
 use syn::{
     Attribute, Data, DeriveInput, Expr, Field, Fields, Ident, LitStr, Path, PathArguments, Type,
 };
-
-use std::{collections::HashSet, fmt};
 
 use crate::utils::{ensure_no_generics, metrics_attribute, ParseAttribute};
 

--- a/crates/vise-macros/src/metrics.rs
+++ b/crates/vise-macros/src/metrics.rs
@@ -1,12 +1,12 @@
 //! Derivation of the `Metrics` trait.
 
+use std::fmt;
+
 use proc_macro::TokenStream;
 use quote::{quote, quote_spanned};
 use syn::{
     spanned::Spanned, Attribute, Data, DeriveInput, Expr, Field, Ident, Lit, LitStr, Path, Type,
 };
-
-use std::fmt;
 
 use crate::utils::{ensure_no_generics, metrics_attribute, ParseAttribute};
 

--- a/crates/vise-macros/src/metrics.rs
+++ b/crates/vise-macros/src/metrics.rs
@@ -196,11 +196,11 @@ impl MetricsField {
         };
 
         quote! {
-            visitor.push_metric(
+            visitor.visit_metric(
                 #name_str,
                 #docs,
                 #unit,
-                core::clone::Clone::clone(&self.#name),
+                ::std::boxed::Box::new(::core::clone::Clone::clone(&self.#name)),
             );
         }
     }
@@ -339,7 +339,7 @@ impl MetricsImpl {
             impl #cr::Metrics for #name {
                 const DESCRIPTOR: #cr::descriptors::MetricGroupDescriptor = #descriptor;
 
-                fn visit_metrics(&self, visitor: &mut #cr::MetricsVisitor<'_>) {
+                fn visit_metrics(&self, visitor: &mut dyn #cr::MetricsVisitor) {
                     #(#visit_fields;)*
                 }
             }

--- a/crates/vise-macros/src/metrics.rs
+++ b/crates/vise-macros/src/metrics.rs
@@ -151,7 +151,7 @@ impl MetricsField {
                 docs.push_str(line);
             }
         }
-        if docs.ends_with(|ch: char| ch == '.' || ch == '!' || ch == '?') {
+        if docs.ends_with(['.', '!', '?']) {
             // Remove the trailing punctuation since it'll be inserted automatically by the `Registry`.
             docs.pop();
         }

--- a/crates/vise-macros/src/register.rs
+++ b/crates/vise-macros/src/register.rs
@@ -1,10 +1,10 @@
 //! `register` attribute macro.
 
+use std::fmt;
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Attribute, ItemStatic, Path};
-
-use std::fmt;
 
 use crate::utils::{metrics_attribute, ParseAttribute};
 

--- a/crates/vise/README.md
+++ b/crates/vise/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/matter-labs/vise/workflows/Rust/badge.svg?branch=main)](https://github.com/matter-labs/vise/actions)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/matter-labs/vise#license)
-![rust 1.70+ required](https://img.shields.io/badge/rust-1.70+-blue.svg?label=Required%20Rust)
+![rust 1.79+ required](https://img.shields.io/badge/rust-1.79+-blue.svg?label=Required%20Rust)
 
 **Documentation:**
 [![crate docs (main)](https://img.shields.io/badge/main-yellow.svg?label=docs)](https://matter-labs.github.io/vise/vise/)

--- a/crates/vise/src/buckets.rs
+++ b/crates/vise/src/buckets.rs
@@ -1,6 +1,6 @@
-use compile_fmt::{compile_assert, fmt};
-
 use std::{cmp, iter, mem, ops};
+
+use compile_fmt::{compile_assert, fmt};
 
 #[derive(Debug, Clone, Copy)]
 enum BucketsInner {

--- a/crates/vise/src/builder.rs
+++ b/crates/vise/src/builder.rs
@@ -1,6 +1,6 @@
-use prometheus_client::{encoding::EncodeMetric, metrics::counter::Counter};
-
 use std::hash::Hash;
+
+use prometheus_client::{encoding::EncodeMetric, metrics::counter::Counter};
 
 use crate::{
     traits::{EncodeLabelSet, GaugeValue, HistogramValue},

--- a/crates/vise/src/builder.rs
+++ b/crates/vise/src/builder.rs
@@ -1,14 +1,11 @@
-use prometheus_client::{
-    encoding::{EncodeLabelSet, EncodeMetric},
-    metrics::{counter::Counter, TypedMetric},
-};
+use prometheus_client::{encoding::EncodeMetric, metrics::counter::Counter};
 
 use std::hash::Hash;
 
 use crate::{
-    traits::{GaugeValue, HistogramValue},
+    traits::{EncodeLabelSet, GaugeValue, HistogramValue},
     wrappers::{Family, Gauge, Histogram, Info},
-    Buckets,
+    Buckets, Metrics,
 };
 
 /// Builder of a single metric or a [`Family`] of metrics. Parameterized by buckets
@@ -57,7 +54,7 @@ impl<B> MetricBuilder<B> {
 }
 
 /// Metric that can be constructed from a [`MetricBuilder`].
-pub trait BuildMetric: 'static + Sized + EncodeMetric + TypedMetric {
+pub trait BuildMetric: 'static + Sized /*+ EncodeMetric + TypedMetric*/ {
     /// Metric builder used to construct a metric.
     type Builder: Copy;
 
@@ -116,5 +113,13 @@ where
             labels: (),
         };
         Family::new(item_builder, builder.labels)
+    }
+}
+
+impl<M: Metrics + Default> BuildMetric for M {
+    type Builder = (); // FIXME: ??
+
+    fn build(_builder: Self::Builder) -> Self {
+        Self::default()
     }
 }

--- a/crates/vise/src/builder.rs
+++ b/crates/vise/src/builder.rs
@@ -117,9 +117,9 @@ where
 }
 
 impl<M: Metrics + Default> BuildMetric for M {
-    type Builder = (); // FIXME: ??
+    type Builder = ();
 
-    fn build(_builder: Self::Builder) -> Self {
+    fn build((): Self::Builder) -> Self {
         Self::default()
     }
 }

--- a/crates/vise/src/collector.rs
+++ b/crates/vise/src/collector.rs
@@ -6,7 +6,7 @@ use std::{error, fmt};
 use crate::{
     descriptors::MetricGroupDescriptor,
     registry::{CollectToRegistry, MetricsVisitor, Registry},
-    Global, Metrics,
+    Metrics,
 };
 
 type CollectorFn<M> = Box<dyn Fn() -> M + Send + Sync>;
@@ -115,8 +115,8 @@ impl<M: Metrics> fmt::Debug for LazyGlobalCollector<M> {
 }
 
 impl<M: Metrics> LazyGlobalCollector<M> {
-    pub(crate) fn new(metrics: &'static Global<M>) -> Self {
-        Self(&metrics.0)
+    pub(crate) fn new(metrics: &'static Lazy<M>) -> Self {
+        Self(metrics)
     }
 }
 

--- a/crates/vise/src/collector.rs
+++ b/crates/vise/src/collector.rs
@@ -1,12 +1,11 @@
+use std::{error, fmt};
+
 use once_cell::sync::{Lazy, OnceCell};
 use prometheus_client::{collector::Collector as CollectorTrait, encoding::DescriptorEncoder};
 
-use std::{error, fmt};
-
-use crate::registry::MetricsEncoder;
 use crate::{
     descriptors::MetricGroupDescriptor,
-    registry::{CollectToRegistry, Registry},
+    registry::{CollectToRegistry, MetricsEncoder, Registry},
     Metrics,
 };
 
@@ -135,12 +134,12 @@ impl<M: Metrics> CollectorTrait for LazyGlobalCollector<M> {
 
 #[cfg(test)]
 mod tests {
-    use once_cell::sync::Lazy;
-
     use std::sync::{
         atomic::{AtomicI64, Ordering},
         Arc,
     };
+
+    use once_cell::sync::Lazy;
 
     use super::*;
     use crate::{Format, Gauge, Registry, Unit};

--- a/crates/vise/src/descriptors.rs
+++ b/crates/vise/src/descriptors.rs
@@ -65,9 +65,9 @@ impl FullMetricDescriptor {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
-
     use std::collections::HashMap;
+
+    use assert_matches::assert_matches;
 
     use super::*;
     use crate::{metrics::Metrics, tests::TestMetrics};

--- a/crates/vise/src/encoding.rs
+++ b/crates/vise/src/encoding.rs
@@ -1,12 +1,12 @@
-use crate::MetricsVisitor;
-use prometheus_client::encoding::{EncodeMetric, LabelSetEncoder, MetricEncoder};
-use prometheus_client::metrics::MetricType;
-use prometheus_client::registry::{Metric, Unit};
-use std::collections::HashMap;
-use std::fmt;
-use std::sync::Arc;
+use std::{collections::HashMap, fmt, sync::Arc};
 
-use crate::traits::EncodeLabelSet;
+use prometheus_client::{
+    encoding::{EncodeMetric, LabelSetEncoder, MetricEncoder},
+    metrics::MetricType,
+    registry::{Metric, Unit},
+};
+
+use crate::{traits::EncodeLabelSet, MetricsVisitor};
 
 /// Wraps a label set so that it can be used in the `prometheus_client` library.
 #[derive(Debug)]

--- a/crates/vise/src/encoding.rs
+++ b/crates/vise/src/encoding.rs
@@ -1,0 +1,88 @@
+use prometheus_client::encoding::{EncodeMetric, LabelSetEncoder, MetricEncoder};
+use std::fmt;
+
+use crate::traits::EncodeLabelSet;
+
+#[derive(Debug)]
+pub(crate) struct LabelSetWrapper<S>(pub S);
+
+impl<S: EncodeLabelSet> prometheus_client::encoding::EncodeLabelSet for LabelSetWrapper<S> {
+    fn encode(&self, mut encoder: LabelSetEncoder<'_>) -> fmt::Result {
+        self.0.encode(&mut encoder)
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct LabelGroups(pub(crate) Vec<Box<dyn EncodeLabelSet>>);
+
+impl fmt::Debug for LabelGroups {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LabelGroups")
+            .field("len", &self.0.len())
+            .finish()
+    }
+}
+
+impl LabelGroups {
+    const EMPTY: &'static Self = &Self(Vec::new());
+}
+
+#[derive(Debug)]
+struct FullLabelSet<'a, S> {
+    inner: &'a S,
+    label_groups: &'a LabelGroups,
+}
+
+impl<S: EncodeLabelSet> prometheus_client::encoding::EncodeLabelSet for FullLabelSet<'_, S> {
+    fn encode(&self, mut encoder: LabelSetEncoder<'_>) -> fmt::Result {
+        for group in &self.label_groups.0 {
+            group.encode(&mut encoder)?;
+        }
+        self.inner.encode(&mut encoder)
+    }
+}
+
+#[derive(Debug)]
+pub struct AdvancedMetricEncoder<'a> {
+    inner: MetricEncoder<'a>,
+    label_groups: &'a LabelGroups,
+}
+
+impl<'a> From<MetricEncoder<'a>> for AdvancedMetricEncoder<'a> {
+    fn from(inner: MetricEncoder<'a>) -> Self {
+        Self {
+            inner,
+            label_groups: LabelGroups::EMPTY,
+        }
+    }
+}
+
+impl<'a> AdvancedMetricEncoder<'a> {
+    pub(crate) fn new(inner: MetricEncoder<'a>, label_groups: &'a LabelGroups) -> Self {
+        Self {
+            inner,
+            label_groups,
+        }
+    }
+
+    pub(crate) fn encode_family<'s>(
+        &'s mut self,
+        label_set: &'s impl EncodeLabelSet,
+        action: impl FnOnce(MetricEncoder<'_>) -> fmt::Result,
+    ) -> fmt::Result {
+        let full_label_set = FullLabelSet {
+            inner: label_set,
+            label_groups: self.label_groups,
+        };
+        let encoder = self.inner.encode_family(&full_label_set)?;
+        action(encoder)
+    }
+}
+
+// TODO: docs, better name
+pub trait AdvancedMetric: EncodeMetric {
+    fn advanced_encode(&self, encoder: AdvancedMetricEncoder<'_>) -> fmt::Result {
+        self.encode(encoder.inner)
+    }
+}

--- a/crates/vise/src/encoding.rs
+++ b/crates/vise/src/encoding.rs
@@ -1,10 +1,10 @@
-use prometheus_client::encoding::{
-    DescriptorEncoder, EncodeMetric, LabelSetEncoder, MetricEncoder,
-};
+use crate::MetricsVisitor;
+use prometheus_client::encoding::{EncodeMetric, LabelSetEncoder, MetricEncoder};
 use prometheus_client::metrics::MetricType;
 use prometheus_client::registry::{Metric, Unit};
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::Arc;
 
 use crate::traits::EncodeLabelSet;
 
@@ -17,150 +17,148 @@ impl<S: EncodeLabelSet> prometheus_client::encoding::EncodeLabelSet for LabelSet
     }
 }
 
-struct GroupedMetricInstances {
-    help: &'static str,
-    unit: Option<Unit>,
-    instances: Vec<(usize, Box<dyn EncodeGroupedMetric>)>,
-}
+#[derive(Default)]
+struct LabeledMetric(Vec<(Arc<dyn EncodeLabelSet>, Box<dyn GroupedMetric>)>);
 
-impl fmt::Debug for GroupedMetricInstances {
+impl fmt::Debug for LabeledMetric {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
-            .debug_struct("GroupedMetric")
-            .field("help", &self.help)
-            .field("unit", &self.unit)
-            .finish_non_exhaustive()
+            .debug_struct("LabeledMetric")
+            .field("len", &self.0.len())
+            .finish()
     }
+}
+
+impl EncodeMetric for LabeledMetric {
+    fn encode(&self, mut encoder: MetricEncoder<'_>) -> fmt::Result {
+        for (labels, metric) in &self.0 {
+            metric
+                .as_ref()
+                .encode_grouped(labels.as_ref(), &mut encoder)?;
+        }
+        Ok(())
+    }
+
+    fn metric_type(&self) -> MetricType {
+        self.0
+            .first()
+            .map_or(MetricType::Unknown, |(_, metric)| metric.metric_type())
+    }
+}
+
+impl EncodeGroupedMetric for LabeledMetric {
+    fn encode_grouped(
+        &self,
+        _group_labels: &dyn EncodeLabelSet,
+        _encoder: &mut MetricEncoder<'_>,
+    ) -> fmt::Result {
+        todo!("compose labels")
+    }
+}
+
+#[derive(Debug)]
+struct MetricsGroup {
+    help: &'static str,
+    unit: Option<Unit>,
+    instances: LabeledMetric,
 }
 
 /// Buffer for metrics in a `MetricsFamily`. Allows collecting metrics from all groups in the family,
 /// so that they can be encoded grouped by metric (as opposed to by the group label set).
 #[derive(Default)]
 pub(crate) struct LabelGroups {
-    labels: Vec<Box<dyn EncodeLabelSet>>,
-    metrics_by_name: HashMap<&'static str, GroupedMetricInstances>,
+    labels: Option<Arc<dyn EncodeLabelSet>>,
+    metrics_by_name: HashMap<&'static str, MetricsGroup>,
 }
 
 impl fmt::Debug for LabelGroups {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("LabelGroups")
-            .field("labels", &self.labels.len())
             .field("metrics_by_name", &self.metrics_by_name)
-            .finish()
-    }
-}
-
-impl LabelGroups {
-    pub(crate) fn push_labels(&mut self, labels: Box<dyn EncodeLabelSet>) {
-        self.labels.push(labels);
-    }
-
-    pub(crate) fn push_metric(
-        &mut self,
-        name: &'static str,
-        help: &'static str,
-        unit: Option<&Unit>,
-        metric: Box<dyn EncodeGroupedMetric>,
-    ) {
-        let metric_entry =
-            self.metrics_by_name
-                .entry(name)
-                .or_insert_with(|| GroupedMetricInstances {
-                    help,
-                    unit: unit.cloned(),
-                    instances: vec![],
-                });
-        let current_group_idx = self.labels.len() - 1;
-        metric_entry.instances.push((current_group_idx, metric));
-    }
-
-    pub(crate) fn encode(self, encoder: &mut DescriptorEncoder<'_>) -> fmt::Result {
-        for (name, grouped_metric) in self.metrics_by_name {
-            let Some((_, metric)) = grouped_metric.instances.first() else {
-                continue;
-            };
-            let instances = grouped_metric
-                .instances
-                .iter()
-                .map(|(idx, metric)| (self.labels[*idx].as_ref(), metric.as_ref()));
-
-            let metric_encoder = encoder.encode_descriptor(
-                name,
-                grouped_metric.help,
-                grouped_metric.unit.as_ref(),
-                metric.metric_type(),
-            )?;
-            let mut metric_encoder = GroupedMetricEncoder {
-                inner: metric_encoder,
-                group_labels: &(),
-            };
-            for (group_labels, instance) in instances {
-                metric_encoder.group_labels = group_labels;
-                instance.encode_grouped(&mut metric_encoder)?;
-            }
-        }
-        Ok(())
-    }
-}
-
-struct FullLabelSet<'a, S> {
-    inner: &'a S,
-    group_labels: &'a dyn EncodeLabelSet,
-}
-
-impl<S: fmt::Debug> fmt::Debug for FullLabelSet<'_, S> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("FullLabelSet")
-            .field("inner", self.inner)
             .finish_non_exhaustive()
     }
 }
 
-impl<S: EncodeLabelSet> prometheus_client::encoding::EncodeLabelSet for FullLabelSet<'_, S> {
+impl MetricsVisitor for LabelGroups {
+    fn visit_metric(
+        &mut self,
+        name: &'static str,
+        help: &'static str,
+        unit: Option<Unit>,
+        metric: Box<dyn GroupedMetric>,
+    ) {
+        let metric_entry = self
+            .metrics_by_name
+            .entry(name)
+            .or_insert_with(|| MetricsGroup {
+                help,
+                unit,
+                instances: LabeledMetric::default(),
+            });
+        let current_labels = self
+            .labels
+            .clone()
+            .expect("`LabelGroups` misused: group labels must be set before visiting metrics");
+        metric_entry.instances.0.push((current_labels, metric));
+    }
+}
+
+impl LabelGroups {
+    pub(crate) fn set_labels(&mut self, labels: Arc<dyn EncodeLabelSet>) {
+        self.labels = Some(labels);
+    }
+
+    pub(crate) fn visit_metrics(self, visitor: &mut dyn MetricsVisitor) {
+        for (name, grouped_metric) in self.metrics_by_name {
+            visitor.visit_metric(
+                name,
+                grouped_metric.help,
+                grouped_metric.unit,
+                Box::new(grouped_metric.instances),
+            );
+        }
+    }
+}
+
+pub(crate) struct FullLabelSet<'a> {
+    group_labels: &'a dyn EncodeLabelSet,
+    inner: &'a dyn EncodeLabelSet,
+}
+
+impl fmt::Debug for FullLabelSet<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FullLabelSet")
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> FullLabelSet<'a> {
+    pub(crate) fn new(group_labels: &'a dyn EncodeLabelSet, inner: &'a dyn EncodeLabelSet) -> Self {
+        Self {
+            group_labels,
+            inner,
+        }
+    }
+}
+
+impl prometheus_client::encoding::EncodeLabelSet for FullLabelSet<'_> {
     fn encode(&self, mut encoder: LabelSetEncoder<'_>) -> fmt::Result {
         self.group_labels.encode(&mut encoder)?;
         self.inner.encode(&mut encoder)
     }
 }
 
-pub struct GroupedMetricEncoder<'a> {
-    inner: MetricEncoder<'a>,
-    group_labels: &'a dyn EncodeLabelSet,
-}
-
-impl fmt::Debug for GroupedMetricEncoder<'_> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("GroupedMetricEncoder")
-            .field("inner", &self.inner)
-            .finish_non_exhaustive()
-    }
-}
-
-impl<'a> GroupedMetricEncoder<'a> {
-    pub(crate) fn encode_family<'s>(
-        &'s mut self,
-        label_set: &'s impl EncodeLabelSet,
-        action: impl FnOnce(MetricEncoder<'_>) -> fmt::Result,
-    ) -> fmt::Result {
-        let full_label_set = FullLabelSet {
-            inner: label_set,
-            group_labels: self.group_labels,
-        };
-        let encoder = self.inner.encode_family(&full_label_set)?;
-        action(encoder)
-    }
-}
-
-// FIXME: rework
 /// Encodes a metric inside [a group](crate::MetricsFamily).
 pub trait EncodeGroupedMetric: EncodeMetric {
-    fn encode_grouped(&self, encoder: &mut GroupedMetricEncoder<'_>) -> fmt::Result {
-        let labels = LabelSetWrapper(encoder.group_labels);
-        let encoder = encoder.inner.encode_family(&labels)?;
-        self.encode(encoder)
+    fn encode_grouped(
+        &self,
+        labels: &dyn EncodeLabelSet,
+        encoder: &mut MetricEncoder<'_>,
+    ) -> fmt::Result {
+        let labels = LabelSetWrapper(labels);
+        self.encode(encoder.encode_family(&labels)?)
     }
 }
 

--- a/crates/vise/src/format.rs
+++ b/crates/vise/src/format.rs
@@ -1,8 +1,8 @@
 //! Support for various metrics encoding formats.
 
-use prometheus_client::metrics::MetricType;
-
 use std::{fmt, mem};
+
+use prometheus_client::metrics::MetricType;
 
 /// Metrics export format.
 ///

--- a/crates/vise/src/lib.rs
+++ b/crates/vise/src/lib.rs
@@ -414,7 +414,7 @@ pub use crate::{
     builder::{BuildMetric, MetricBuilder},
     collector::{BeforeScrapeError, Collector},
     format::Format,
-    metrics::{Global, Metrics},
+    metrics::{Global, Metrics, MetricsFamily},
     registry::{
         CollectToRegistry, MetricsCollection, MetricsVisitor, RegisteredDescriptors, Registry,
         METRICS_REGISTRATIONS,

--- a/crates/vise/src/lib.rs
+++ b/crates/vise/src/lib.rs
@@ -398,6 +398,7 @@ mod buckets;
 mod builder;
 mod collector;
 pub mod descriptors;
+mod encoding;
 mod format;
 mod metrics;
 mod registry;

--- a/crates/vise/src/lib.rs
+++ b/crates/vise/src/lib.rs
@@ -16,6 +16,7 @@
 //!   metric data in the OpenMetrics text format. Registration can be automated using the [`register`]
 //!   attribute, but it can be manual as well.
 //! - In order to allow for metrics computed during scraping, you can use [`Collector`].
+//! - To share one or more labels for a group of metrics, wrap them in a [`MetricsFamily`].
 //!
 //! # Examples
 //!
@@ -241,7 +242,7 @@ pub use vise_macros::EncodeLabelValue;
 ///
 /// `Option` fields are skipped by default if they are `None` (i.e., they use `skip = Option::is_none`).
 ///
-/// [`EncodeLabelSet`]: trait@prometheus_client::encoding::EncodeLabelSet
+/// [`EncodeLabelSet`]: crate::traits::EncodeLabelSet
 ///
 /// ## `unit`
 ///

--- a/crates/vise/src/metrics.rs
+++ b/crates/vise/src/metrics.rs
@@ -3,8 +3,10 @@
 use once_cell::sync::Lazy;
 use std::hash::Hash;
 
+use std::sync::Arc;
 use std::{fmt, ops};
 
+use crate::encoding::LabelGroups;
 use crate::wrappers::FamilyInner;
 use crate::{
     descriptors::MetricGroupDescriptor,
@@ -128,8 +130,13 @@ where
 {
     const DESCRIPTOR: MetricGroupDescriptor = M::DESCRIPTOR;
 
-    fn visit_metrics(&self, _visitor: &mut dyn MetricsVisitor) {
-        todo!("collect into groups, then visit")
+    fn visit_metrics(&self, visitor: &mut dyn MetricsVisitor) {
+        let mut grouped = LabelGroups::default();
+        for (labels, metrics) in self.to_entries() {
+            grouped.set_labels(Arc::new(labels));
+            metrics.visit_metrics(&mut grouped);
+        }
+        grouped.visit_metrics(visitor);
     }
 }
 

--- a/crates/vise/src/metrics.rs
+++ b/crates/vise/src/metrics.rs
@@ -1,17 +1,15 @@
 //! Core `Metrics` trait defined by the crate.
 
+use std::{fmt, hash::Hash, ops, sync::Arc};
+
 use once_cell::sync::Lazy;
-use std::hash::Hash;
 
-use std::sync::Arc;
-use std::{fmt, ops};
-
-use crate::encoding::LabelGroups;
-use crate::wrappers::FamilyInner;
 use crate::{
     descriptors::MetricGroupDescriptor,
+    encoding::LabelGroups,
     registry::{CollectToRegistry, MetricsVisitor, Registry},
     traits::EncodeLabelSet,
+    wrappers::FamilyInner,
 };
 
 /// Collection of metrics for a library or application. Should be derived using the corresponding macro.

--- a/crates/vise/src/registry.rs
+++ b/crates/vise/src/registry.rs
@@ -96,7 +96,7 @@ impl Default for MetricsCollection {
 impl MetricsCollection {
     /// Specifies that metrics should be lazily exported.
     ///
-    /// By default, [`Global`] metrics are eagerly collected into a [`Registry`]; i.e., metrics will get exported
+    /// By default, [`Global`](crate::Global) metrics are eagerly collected into a [`Registry`]; i.e., metrics will get exported
     /// even if they were never modified by the app / library logic. This is *usually* fine (e.g.,
     /// this allows getting all metrics metadata on the first scrape), but sometimes you may want to
     /// export only metrics touched by the app / library logic. E.g., you have a single app binary
@@ -128,7 +128,7 @@ impl MetricsCollection {
 }
 
 impl<F: FnMut(&MetricGroupDescriptor) -> bool> MetricsCollection<F> {
-    /// Creates a registry with all [`register`](crate::register)ed [`Global`] metrics
+    /// Creates a registry with all [`register`](crate::register)ed [`Global`](crate::Global) metrics
     /// and [`Collector`]s. If a filtering predicate [was provided](MetricsCollection::filter()),
     /// only metrics satisfying this function will be collected.
     #[allow(clippy::missing_panics_doc)]
@@ -284,9 +284,10 @@ impl Registry {
     }
 }
 
-/// FIXME
+/// Visitor for [`Metrics`].
 pub trait MetricsVisitor {
-    /// FIXME
+    /// Visits a specific metric instance.
+    #[doc(hidden)] // implementation detail
     fn visit_metric(
         &mut self,
         name: &'static str,
@@ -353,7 +354,7 @@ impl MetricsVisitor for MetricsEncoder<'_> {
 }
 
 /// Collects metrics from this type to registry. This is used by the [`register`](crate::register)
-/// macro to handle registration of [`Global`] metrics and [`Collector`]s.
+/// macro to handle registration of [`Global`](crate::Global) metrics and [`Collector`]s.
 pub trait CollectToRegistry: 'static + Send + Sync {
     #[doc(hidden)] // implementation detail
     fn descriptor(&self) -> &'static MetricGroupDescriptor;

--- a/crates/vise/src/registry.rs
+++ b/crates/vise/src/registry.rs
@@ -1,18 +1,17 @@
 //! Wrapper around metrics registry.
 
+use std::{collections::HashMap, fmt, sync::Mutex};
+
+use once_cell::sync::Lazy;
 use prometheus_client::{
     encoding::{text, DescriptorEncoder},
     registry::{Registry as RegistryInner, Unit},
 };
 
-use once_cell::sync::Lazy;
-use std::sync::Mutex;
-use std::{collections::HashMap, fmt};
-
-use crate::encoding::GroupedMetric;
 use crate::{
     collector::{Collector, LazyGlobalCollector},
     descriptors::{FullMetricDescriptor, MetricGroupDescriptor},
+    encoding::GroupedMetric,
     format::{Format, PrometheusWrapper},
     Metrics,
 };

--- a/crates/vise/src/registry.rs
+++ b/crates/vise/src/registry.rs
@@ -10,7 +10,7 @@ use prometheus_client::registry::Metric;
 use std::sync::Mutex;
 use std::{collections::HashMap, fmt};
 
-use crate::encoding::{AdvancedMetric, LabelGroups};
+use crate::encoding::{EncodeGroupedMetric, LabelGroups};
 use crate::{
     collector::{Collector, LazyGlobalCollector},
     descriptors::{FullMetricDescriptor, MetricGroupDescriptor},
@@ -368,7 +368,7 @@ impl<'a> MetricsVisitor<'a> {
         name: &'static str,
         help: &'static str,
         unit: Option<Unit>,
-        metric: impl AdvancedMetric + Metric + 'static,
+        metric: impl EncodeGroupedMetric + Metric + 'static,
     ) {
         match &mut self.0 {
             MetricsVisitorInner::Registry(registry) => {
@@ -405,7 +405,7 @@ impl<'a> MetricsVisitor<'a> {
         help: &'static str,
         unit: Option<&Unit>,
         label_groups: Option<&mut LabelGroups>,
-        metric: impl AdvancedMetric + 'static,
+        metric: impl EncodeGroupedMetric + 'static,
     ) -> fmt::Result {
         if let Some(label_groups) = label_groups {
             label_groups.push_metric(name, help, unit, Box::new(metric));

--- a/crates/vise/src/registry.rs
+++ b/crates/vise/src/registry.rs
@@ -284,7 +284,9 @@ impl Registry {
     }
 }
 
+/// FIXME
 pub trait MetricsVisitor {
+    /// FIXME
     fn visit_metric(
         &mut self,
         name: &'static str,

--- a/crates/vise/src/tests.rs
+++ b/crates/vise/src/tests.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::float_cmp)]
 
+use std::time::Duration;
+
 use assert_matches::assert_matches;
 use derive_more::Display;
-
-use std::time::Duration;
 
 use super::*;
 

--- a/crates/vise/src/traits.rs
+++ b/crates/vise/src/traits.rs
@@ -264,7 +264,10 @@ pub trait MapLabels<S>: Copy {
 
 /// Identity mapping.
 impl<S: EncodeLabelSet> MapLabels<S> for () {
-    type Output<'a> = LabelRef<'a, S> where S: 'a;
+    type Output<'a>
+        = LabelRef<'a, S>
+    where
+        S: 'a;
 
     fn map_labels<'a>(&'a self, labels: &'a S) -> Self::Output<'a> {
         LabelRef(labels)
@@ -298,7 +301,10 @@ pub struct StaticLabelSet<'a, S: 'a> {
 }
 
 impl<S: EncodeLabelValue + Send + Sync> MapLabels<S> for [&'static str; 1] {
-    type Output<'a> = StaticLabelSet<'a, (&'a S,)> where S: 'a;
+    type Output<'a>
+        = StaticLabelSet<'a, (&'a S,)>
+    where
+        S: 'a;
 
     fn map_labels<'a>(&'a self, labels: &'a S) -> Self::Output<'a> {
         StaticLabelSet {

--- a/crates/vise/src/traits.rs
+++ b/crates/vise/src/traits.rs
@@ -24,6 +24,12 @@ pub trait EncodeLabelSet {
     fn encode(&self, encoder: &mut LabelSetEncoder<'_>) -> fmt::Result;
 }
 
+impl EncodeLabelSet for () {
+    fn encode(&self, _encoder: &mut LabelSetEncoder<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
+
 impl<T: EncodeLabelSet + ?Sized> EncodeLabelSet for &T {
     fn encode(&self, encoder: &mut LabelSetEncoder<'_>) -> fmt::Result {
         (**self).encode(encoder)

--- a/crates/vise/src/traits.rs
+++ b/crates/vise/src/traits.rs
@@ -1,14 +1,14 @@
 //! Traits used for metric definitions, such as [`GaugeValue`] and [`HistogramValue`].
 
-use prometheus_client::{
-    encoding::{EncodeLabel, EncodeLabelValue, LabelSetEncoder, LabelValueEncoder},
-    metrics::gauge,
-};
-
 use std::{
     fmt,
     sync::atomic::{AtomicI64, AtomicIsize, AtomicU64, AtomicUsize, Ordering},
     time::Duration,
+};
+
+use prometheus_client::{
+    encoding::{EncodeLabel, EncodeLabelValue, LabelSetEncoder, LabelValueEncoder},
+    metrics::gauge,
 };
 
 /// Encodes a label set.

--- a/crates/vise/src/wrappers.rs
+++ b/crates/vise/src/wrappers.rs
@@ -1,5 +1,15 @@
 //! Wrappers for metric types defined in `prometheus-client`.
 
+use std::{
+    collections::HashMap,
+    fmt,
+    hash::Hash,
+    marker::PhantomData,
+    ops,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
 use elsa::sync::FrozenMap;
 use once_cell::sync::OnceCell;
 use prometheus_client::{
@@ -14,20 +24,10 @@ use prometheus_client::{
     registry::Unit,
 };
 
-use std::{
-    collections::HashMap,
-    fmt,
-    hash::Hash,
-    marker::PhantomData,
-    ops,
-    sync::Arc,
-    time::{Duration, Instant},
-};
-
-use crate::encoding::{EncodeGroupedMetric, FullLabelSet, LabelSetWrapper};
 use crate::{
     buckets::Buckets,
     builder::BuildMetric,
+    encoding::{EncodeGroupedMetric, FullLabelSet, LabelSetWrapper},
     traits::{EncodeLabelSet, EncodedGaugeValue, GaugeValue, HistogramValue, MapLabels},
 };
 
@@ -570,12 +570,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use prometheus_client::metrics::family::Family as StandardFamily;
-
-    use crate::MetricBuilder;
     use std::{sync::mpsc, thread};
 
+    use prometheus_client::metrics::family::Family as StandardFamily;
+
     use super::*;
+    use crate::MetricBuilder;
 
     type Label = (&'static str, &'static str);
 

--- a/crates/vise/src/wrappers.rs
+++ b/crates/vise/src/wrappers.rs
@@ -24,7 +24,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::encoding::{AdvancedMetric, AdvancedMetricEncoder, LabelSetWrapper};
+use crate::encoding::{EncodeGroupedMetric, GroupedMetricEncoder, LabelSetWrapper};
 use crate::{
     buckets::Buckets,
     builder::BuildMetric,
@@ -70,7 +70,7 @@ impl EncodeLabelValue for DurationAsSecs {
     }
 }
 
-impl<N, A> AdvancedMetric for Counter<N, A> where Self: EncodeMetric + TypedMetric {}
+impl<N, A> EncodeGroupedMetric for Counter<N, A> where Self: EncodeMetric + TypedMetric {}
 
 /// Gauge metric.
 ///
@@ -152,7 +152,7 @@ impl<V: GaugeValue> TypedMetric for Gauge<V> {
     const TYPE: MetricType = MetricType::Gauge;
 }
 
-impl<V: GaugeValue> AdvancedMetric for Gauge<V> {}
+impl<V: GaugeValue> EncodeGroupedMetric for Gauge<V> {}
 
 /// Guard for a [`Gauge`] returned by [`Gauge::inc_guard()`]. When dropped, a guard decrements
 /// the gauge by the same value that it was increased by when creating the guard.
@@ -228,7 +228,7 @@ impl<V: HistogramValue> TypedMetric for Histogram<V> {
     const TYPE: MetricType = MetricType::Histogram;
 }
 
-impl<V: HistogramValue> AdvancedMetric for Histogram<V> {}
+impl<V: HistogramValue> EncodeGroupedMetric for Histogram<V> {}
 
 /// Observer of latency for a [`Histogram`].
 #[must_use = "`LatencyObserver` should be `observe()`d"]
@@ -300,7 +300,7 @@ impl<S: EncodeLabelSet> TypedMetric for Info<S> {
     const TYPE: MetricType = MetricType::Info;
 }
 
-impl<S: EncodeLabelSet> AdvancedMetric for Info<S> {}
+impl<S: EncodeLabelSet> EncodeGroupedMetric for Info<S> {}
 
 /// Error returned from [`Info::set()`].
 #[derive(Debug)]
@@ -547,13 +547,13 @@ impl<S, M: BuildMetric + TypedMetric, L> TypedMetric for Family<S, M, L> {
     const TYPE: MetricType = <M as TypedMetric>::TYPE;
 }
 
-impl<S, M, L> AdvancedMetric for Family<S, M, L>
+impl<S, M, L> EncodeGroupedMetric for Family<S, M, L>
 where
     M: BuildMetric + EncodeMetric + TypedMetric,
     S: Clone + Eq + Hash,
     L: MapLabels<S>,
 {
-    fn advanced_encode(&self, encoder: &mut AdvancedMetricEncoder<'_>) -> fmt::Result {
+    fn encode_grouped(&self, encoder: &mut GroupedMetricEncoder<'_>) -> fmt::Result {
         for labels in &self.inner.map.keys_cloned() {
             let metric = self.inner.map.get(labels).unwrap();
             let mapped_labels = self.labels.map_labels(labels);

--- a/crates/vise/tests/ui/labels/unimplemented_format.stderr
+++ b/crates/vise/tests/ui/labels/unimplemented_format.stderr
@@ -9,6 +9,6 @@ error[E0277]: `Label` doesn't implement `std::fmt::Display`
   |         $dst.write_fmt($crate::format_args!($($arg)*))
   |                        ------------------------------ in this macro invocation
   |
-  = help: the trait `std::fmt::Display` is not implemented for `Label`, which is required by `&Label: std::fmt::Display`
+  = help: the trait `std::fmt::Display` is not implemented for `Label`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
   = note: this error originates in the macro `$crate::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/vise/tests/ui/metrics/bogus_buckets.stderr
+++ b/crates/vise/tests/ui/metrics/bogus_buckets.stderr
@@ -2,11 +2,12 @@ error[E0277]: the trait bound `Buckets: From<&str>` is not satisfied
  --> tests/ui/metrics/bogus_buckets.rs:6:25
   |
 6 |     #[metrics(buckets = "42")]
-  |                         ^^^^ the trait `From<&str>` is not implemented for `Buckets`, which is required by `&str: Into<Buckets>`
+  |                         ^^^^ the trait `From<&str>` is not implemented for `Buckets`
 7 |     histogram: Histogram<u64>,
   |                --------- required by a bound introduced by this call
   |
-  = help: the trait `From<&'static [f64; _]>` is implemented for `Buckets`
+  = help: the trait `From<&str>` is not implemented for `Buckets`
+          but trait `From<&'static [f64; _]>` is implemented for it
   = help: for that trait implementation, expected `[f64; _]`, found `str`
   = note: required for `&str` to implement `Into<Buckets>`
 note: required by a bound in `MetricBuilder::<(), L>::with_buckets`

--- a/crates/vise/tests/ui/metrics/missing_buckets.stderr
+++ b/crates/vise/tests/ui/metrics/missing_buckets.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<Histogram<u64> as BuildMetric>::Builder 
  --> tests/ui/metrics/missing_buckets.rs:6:16
   |
 6 |     histogram: Histogram<u64>,
-  |                ^^^^^^^^^ expected `MetricBuilder<Buckets>`, found `MetricBuilder`
+  |                ^^^^^^^^^ expected `MetricBuilder`, found `MetricBuilder<Buckets>`
   |
-  = note: expected struct `MetricBuilder<Buckets>`
-             found struct `MetricBuilder<()>`
+  = note: expected struct `MetricBuilder<()>`
+             found struct `MetricBuilder<Buckets>`

--- a/crates/vise/tests/ui/metrics/unnecessary_buckets.stderr
+++ b/crates/vise/tests/ui/metrics/unnecessary_buckets.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<Counter as BuildMetric>::Builder == Metr
  --> tests/ui/metrics/unnecessary_buckets.rs:7:14
   |
 7 |     counter: Counter,
-  |              ^^^^^^^ expected `MetricBuilder`, found `MetricBuilder<Buckets>`
+  |              ^^^^^^^ expected `MetricBuilder<Buckets>`, found `MetricBuilder`
   |
-  = note: expected struct `MetricBuilder<()>`
-             found struct `MetricBuilder<Buckets>`
+  = note: expected struct `MetricBuilder<Buckets>`
+             found struct `MetricBuilder<()>`

--- a/deny.toml
+++ b/deny.toml
@@ -36,7 +36,7 @@ allow = [
   "Apache-2.0",
   "BSD-2-Clause",
   "MIT",
-  "Unicode-DFS-2016",
+  "Unicode-3.0",
 ]
 
 [bans]

--- a/e2e-tests/src/main.rs
+++ b/e2e-tests/src/main.rs
@@ -1,10 +1,9 @@
 //! Mock app that defines `vise` metrics and uses the corresponding exporter.
 
-use rand::{thread_rng, Rng};
-use tokio::sync::watch;
-
 use std::{env, time::Duration};
 
+use rand::{thread_rng, Rng};
+use tokio::sync::watch;
 use vise::{
     Buckets, Counter, EncodeLabelSet, EncodeLabelValue, Family, Format, Gauge, Histogram, Info,
     LabeledFamily, Metrics, Unit,

--- a/e2e-tests/tests/integration.rs
+++ b/e2e-tests/tests/integration.rs
@@ -1,5 +1,13 @@
 //! Integration testing for `vise` exporter.
 
+use std::{
+    collections::HashSet,
+    net::SocketAddr,
+    path::Path,
+    process::{Command as StdCommand, Stdio},
+    time::{Duration, Instant},
+};
+
 use anyhow::Context as _;
 use assert_matches::assert_matches;
 use prometheus_http_query::{response::MetricType, Client, TargetState};
@@ -10,14 +18,6 @@ use tokio::{
     sync::Mutex,
 };
 use tracing::metadata::LevelFilter;
-
-use std::{
-    collections::HashSet,
-    net::SocketAddr,
-    path::Path,
-    process::{Command as StdCommand, Stdio},
-    time::{Duration, Instant},
-};
 
 const PROMETHEUS_CONFIG: &str = r#"
 global:


### PR DESCRIPTION
# What ❔

Allows sharing common label set among multiple metrics using an interface similar to `Family`.

## Why ❔

There are some metric definitions in the Era codebase where this would allow to avoid copy-pasting and improve the interface overall, e.g. for RocksDB storage or Web3 clients.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.