### PR TITLE
feat!: Implement lazy getter for families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 ### Changed
 
 - Bump minimum supported Rust version to 1.79 (#30).
+- Change `Family::to_entries()` to return an iterator (#32).
 
 ## 0.2.0 - 2024-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 ### Added
 
 - Allow sharing common label set among multiple metrics using an interface similar to `Family` (#30).
+- Implement lazy getter for `Family` / `MetricsFamily` (#32).
 
 ### Changed
 

--- a/crates/vise/src/lib.rs
+++ b/crates/vise/src/lib.rs
@@ -397,7 +397,7 @@ pub use crate::{
     },
     wrappers::{
         DurationAsSecs, Family, Gauge, GaugeGuard, Histogram, Info, LabelWithUnit, LabeledFamily,
-        LatencyObserver, SetInfoError, LazyItem,
+        LatencyObserver, LazyItem, SetInfoError,
     },
 };
 

--- a/crates/vise/src/lib.rs
+++ b/crates/vise/src/lib.rs
@@ -397,7 +397,7 @@ pub use crate::{
     },
     wrappers::{
         DurationAsSecs, Family, Gauge, GaugeGuard, Histogram, Info, LabelWithUnit, LabeledFamily,
-        LatencyObserver, SetInfoError,
+        LatencyObserver, SetInfoError, LazyItem,
     },
 };
 

--- a/crates/vise/src/metrics.rs
+++ b/crates/vise/src/metrics.rs
@@ -158,6 +158,12 @@ where
     pub fn get_lazy(&self, labels: S) -> LazyItem<'_, S, M> {
         LazyItem::new(&self.0, labels)
     }
+
+    /// Returns all metrics currently present in this family together with the corresponding labels.
+    /// This is inefficient and mostly useful for testing purposes.
+    pub fn to_entries(&self) -> impl ExactSizeIterator<Item = (S, &M)> + '_ {
+        self.0.to_entries()
+    }
 }
 
 impl<S, M> ops::Index<&S> for MetricsFamily<S, M>

--- a/crates/vise/src/metrics.rs
+++ b/crates/vise/src/metrics.rs
@@ -4,13 +4,7 @@ use std::{fmt, hash::Hash, ops, sync::Arc};
 
 use once_cell::sync::Lazy;
 
-use crate::{
-    descriptors::MetricGroupDescriptor,
-    encoding::LabelGroups,
-    registry::{CollectToRegistry, MetricsVisitor, Registry},
-    traits::EncodeLabelSet,
-    wrappers::FamilyInner,
-};
+use crate::{descriptors::MetricGroupDescriptor, encoding::LabelGroups, LazyItem, registry::{CollectToRegistry, MetricsVisitor, Registry}, traits::EncodeLabelSet, wrappers::FamilyInner};
 
 /// Collection of metrics for a library or application. Should be derived using the corresponding macro.
 pub trait Metrics: 'static + Send + Sync {
@@ -149,6 +143,13 @@ where
     /// Creates a new metrics family.
     pub const fn new() -> Self {
         Self(Lazy::new(|| FamilyInner::new(())))
+    }
+
+    /// Gets or creates metrics with the specified labels *lazily* (i.e., on first access). This is useful
+    /// if the metrics are updated conditionally and the condition is somewhat rare; in this case, indexing can
+    /// unnecessarily blow up the number of metrics in the family.
+    pub fn get_lazy(&self, labels: S) -> LazyItem<'_, S, M> {
+        LazyItem::new(&self.0, labels)
     }
 }
 

--- a/crates/vise/src/metrics.rs
+++ b/crates/vise/src/metrics.rs
@@ -4,7 +4,14 @@ use std::{fmt, hash::Hash, ops, sync::Arc};
 
 use once_cell::sync::Lazy;
 
-use crate::{descriptors::MetricGroupDescriptor, encoding::LabelGroups, LazyItem, registry::{CollectToRegistry, MetricsVisitor, Registry}, traits::EncodeLabelSet, wrappers::FamilyInner};
+use crate::{
+    descriptors::MetricGroupDescriptor,
+    encoding::LabelGroups,
+    registry::{CollectToRegistry, MetricsVisitor, Registry},
+    traits::EncodeLabelSet,
+    wrappers::FamilyInner,
+    LazyItem,
+};
 
 /// Collection of metrics for a library or application. Should be derived using the corresponding macro.
 pub trait Metrics: 'static + Send + Sync {

--- a/crates/vise/src/wrappers.rs
+++ b/crates/vise/src/wrappers.rs
@@ -365,7 +365,7 @@ where
             .insert_with(labels.clone(), || Box::new(M::build(self.builder)))
     }
 
-    pub(crate) fn to_entries(&self) -> impl Iterator<Item = (S, &M)> + '_ {
+    pub(crate) fn to_entries(&self) -> impl ExactSizeIterator<Item = (S, &M)> + '_ {
         let labels = self.map.keys_cloned();
         labels.into_iter().map(|key| {
             let metric = self.map.get(&key).unwrap();
@@ -510,9 +510,8 @@ where
 
     /// Returns all metrics currently present in this family together with the corresponding labels.
     /// This is inefficient and mostly useful for testing purposes.
-    #[allow(clippy::missing_panics_doc)] // false positive
-    pub fn to_entries(&self) -> HashMap<S, &M> {
-        self.inner.to_entries().collect()
+    pub fn to_entries(&self) -> impl ExactSizeIterator<Item = (S, &M)> + '_ {
+        self.inner.to_entries()
     }
 }
 

--- a/crates/vise/src/wrappers.rs
+++ b/crates/vise/src/wrappers.rs
@@ -501,6 +501,13 @@ where
         self.inner.map.get(labels)
     }
 
+    /// Gets or creates a metric with the specified labels *lazily* (i.e., on first access). This is useful
+    /// if the metric is updated conditionally and the condition is somewhat rare; in this case, indexing can
+    /// unnecessarily blow up the number of metrics in the family.
+    pub fn get_lazy(&self, labels: S) -> LazyItem<'_, S, M> {
+        LazyItem::new(&self.inner, labels)
+    }
+
     /// Returns all metrics currently present in this family together with the corresponding labels.
     /// This is inefficient and mostly useful for testing purposes.
     #[allow(clippy::missing_panics_doc)] // false positive
@@ -519,6 +526,55 @@ where
 
     fn index(&self, labels: &S) -> &Self::Output {
         self.inner.get_or_create(labels)
+    }
+}
+
+/// Lazily accessed member of a [`Family`] or [`MetricsFamily`](crate::MetricsFamily). Returned
+/// by `get_lazy()` methods.
+pub struct LazyItem<'a, S, M: BuildMetric> {
+    family: &'a FamilyInner<S, M>,
+    labels: S,
+}
+
+impl<'a, S, M: BuildMetric> LazyItem<'a, S, M> {
+    pub(crate) fn new(family: &'a FamilyInner<S, M>, labels: S) -> Self {
+        Self { family, labels }
+    }
+}
+
+impl<S, M> fmt::Debug for LazyItem<'_, S, M>
+where
+    S: fmt::Debug + Clone + Eq + Hash,
+    M: BuildMetric + fmt::Debug,
+    M::Builder: fmt::Debug,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LazyItem")
+            .field("family", self.family)
+            .field("labels", &self.labels)
+            .finish()
+    }
+}
+
+impl<S: Clone, M: BuildMetric> Clone for LazyItem<'_, S, M> {
+    fn clone(&self) -> Self {
+        Self {
+            family: self.family,
+            labels: self.labels.clone(),
+        }
+    }
+}
+
+impl<S, M> ops::Deref for LazyItem<'_, S, M>
+where
+    S: Clone + Eq + Hash,
+    M: BuildMetric,
+{
+    type Target = M;
+
+    fn deref(&self) -> &Self::Target {
+        self.family.get_or_create(&self.labels)
     }
 }
 


### PR DESCRIPTION
# What ❔

- Implements lazy getter for `Family` / `MetricsFamily` items.
- Changes `Family::to_entries()` to return an iterator.

## Why ❔

This is useful if the metric is updated conditionally and the condition is somewhat rare; in this case, indexing can unnecessarily blow up the number of metrics in the family. There are a couple of such cases in Era (e.g., in `zksync_db_connection`).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.