### PR TITLE
fix: Escape label values

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           toolchain: ${{ env.msrv }}
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Build libraries
         run: cargo build --workspace --exclude vise-e2e-tests --lib --all-features
@@ -45,7 +45,7 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy, rust-src
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Format
         run: cargo fmt --all -- --config imports_granularity=Crate --config group_imports=StdExternalCrate --check
@@ -76,7 +76,7 @@ jobs:
         with:
           toolchain: ${{ env.nightly }}
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Build docs
         run: |

--- a/crates/vise-macros/src/labels.rs
+++ b/crates/vise-macros/src/labels.rs
@@ -401,7 +401,10 @@ impl LabelField {
             let mut key_encoder = label_encoder.encode_label_key()?;
             #encoding::EncodeLabelKey::encode(&#label, &mut key_encoder)?;
             let mut value_encoder = key_encoder.encode_label_value()?;
-            #encoding::EncodeLabelValue::encode(&self.#name, &mut value_encoder)?;
+            {
+                let _guard = #cr::_private::EncodingContext::LabelValue.enter();
+                #encoding::EncodeLabelValue::encode(&self.#name, &mut value_encoder)?;
+            }
             value_encoder.finish()?;
         };
         if let Some(skip) = skip {
@@ -477,7 +480,10 @@ impl EncodeLabelSetImpl {
                 let mut key_encoder = label_encoder.encode_label_key()?;
                 #encoding::EncodeLabelKey::encode(&#label, &mut key_encoder)?;
                 let mut value_encoder = key_encoder.encode_label_value()?;
-                #encoding::EncodeLabelValue::encode(self, &mut value_encoder)?;
+                {
+                    let _guard = #cr::_private::EncodingContext::LabelValue.enter();
+                    #encoding::EncodeLabelValue::encode(self, &mut value_encoder)?;
+                }
                 value_encoder.finish()
             }
         } else {

--- a/crates/vise/src/format.rs
+++ b/crates/vise/src/format.rs
@@ -41,6 +41,8 @@ impl Drop for EncodingContextGuard {
     }
 }
 
+/// **Important:** must be the outermost wrapper (e.g., compared to [`PrometheusWrapper`]) so that buffering logic
+/// in other wrappers doesn't mess with encoding context.
 #[derive(Debug)]
 pub(crate) struct EscapeWrapper<W> {
     inner: W,

--- a/crates/vise/src/lib.rs
+++ b/crates/vise/src/lib.rs
@@ -406,6 +406,10 @@ pub mod _reexports {
     pub use ctor::ctor;
     pub use prometheus_client::{encoding, metrics::TypedMetric};
 }
+#[doc(hidden)] // only used by the proc macros
+pub mod _private {
+    pub use crate::format::EncodingContext;
+}
 
 mod buckets;
 mod builder;

--- a/crates/vise/src/registry.rs
+++ b/crates/vise/src/registry.rs
@@ -268,7 +268,6 @@ impl Registry {
     ///
     /// Proxies formatting errors of the provided `writer`.
     pub fn encode<W: fmt::Write>(&self, writer: &mut W, format: Format) -> fmt::Result {
-        let mut writer = EscapeWrapper::new(writer);
         match format {
             Format::Prometheus | Format::OpenMetricsForPrometheus => {
                 let mut wrapper = PrometheusWrapper::new(writer);
@@ -276,10 +275,10 @@ impl Registry {
                     wrapper.remove_eof_terminator();
                     wrapper.translate_info_metrics_type();
                 }
-                text::encode(&mut wrapper, &self.inner)?;
+                text::encode(&mut EscapeWrapper::new(&mut wrapper), &self.inner)?;
                 wrapper.flush()
             }
-            Format::OpenMetrics => text::encode(&mut writer, &self.inner),
+            Format::OpenMetrics => text::encode(&mut EscapeWrapper::new(writer), &self.inner),
         }
     }
 }

--- a/crates/vise/src/registry.rs
+++ b/crates/vise/src/registry.rs
@@ -12,7 +12,7 @@ use crate::{
     collector::{Collector, LazyGlobalCollector},
     descriptors::{FullMetricDescriptor, MetricGroupDescriptor},
     encoding::GroupedMetric,
-    format::{Format, PrometheusWrapper},
+    format::{EscapeWrapper, Format, PrometheusWrapper},
     Metrics,
 };
 
@@ -268,6 +268,7 @@ impl Registry {
     ///
     /// Proxies formatting errors of the provided `writer`.
     pub fn encode<W: fmt::Write>(&self, writer: &mut W, format: Format) -> fmt::Result {
+        let mut writer = EscapeWrapper::new(writer);
         match format {
             Format::Prometheus | Format::OpenMetricsForPrometheus => {
                 let mut wrapper = PrometheusWrapper::new(writer);
@@ -278,7 +279,7 @@ impl Registry {
                 text::encode(&mut wrapper, &self.inner)?;
                 wrapper.flush()
             }
-            Format::OpenMetrics => text::encode(writer, &self.inner),
+            Format::OpenMetrics => text::encode(&mut writer, &self.inner),
         }
     }
 }

--- a/crates/vise/src/tests.rs
+++ b/crates/vise/src/tests.rs
@@ -551,8 +551,14 @@ fn labeled_family_with_multiple_labels() {
     }
 }
 
-#[test]
-fn escaping_label_values() {
+fn test_escaping_label_values(format: Format) {
+    #[derive(Debug, EncodeLabelSet)]
+    #[metrics(crate = crate)]
+    struct PackageMetadata {
+        version: &'static str,
+        description: &'static str,
+    }
+
     #[derive(Debug, EncodeLabelSet)]
     #[metrics(crate = crate)]
     struct ValueLabels {
@@ -562,39 +568,70 @@ fn escaping_label_values() {
     #[derive(Debug, Metrics)]
     #[metrics(crate = crate, prefix = "escaped")]
     struct EscapedMetrics {
+        package_metadata: Info<PackageMetadata>,
         #[metrics(labels = ["name"])]
         values: LabeledFamily<&'static str, Info<ValueLabels>>,
     }
 
     let metrics = EscapedMetrics::default();
+    metrics
+        .package_metadata
+        .set(PackageMetadata {
+            version: "0.1.0",
+            description: "Multi-line text\nWith \"quotes\" and \"\\\" slashes\n",
+        })
+        .unwrap();
     metrics.values[&"test.value"]
         .set(ValueLabels {
             value: "\"100ms\"".to_owned(),
         })
-        .ok();
+        .unwrap();
     metrics.values[&"test.object"]
         .set(ValueLabels {
             value: "{\n  \"ms\": 100\n}".to_owned(),
         })
-        .ok();
+        .unwrap();
     metrics.values[&"test.backslash"]
         .set(ValueLabels {
             value: "\\ \\ \\".to_owned(),
         })
-        .ok();
+        .unwrap();
 
     let mut registry = Registry::empty();
     registry.register_metrics(&metrics);
     let mut buffer = String::new();
-    registry.encode(&mut buffer, Format::OpenMetrics).unwrap();
-    let lines: Vec<_> = buffer.lines().collect();
+    registry.encode(&mut buffer, format).unwrap();
 
-    let expected_lines = [
-        r#"escaped_values_info{value="{\n  \"ms\": 100\n}",name="test.object"} 1"#,
-        r#"escaped_values_info{value="\"100ms\"",name="test.value"} 1"#,
-        r#"escaped_values_info{value="\\ \\ \\",name="test.backslash"} 1"#,
-    ];
+    let lines: Vec<_> = buffer.lines().collect();
+    let expected_lines = if matches!(format, Format::OpenMetrics) {
+        [
+            r#"escaped_package_metadata_info{version="0.1.0",description="Multi-line text\nWith \"quotes\" and \"\\\" slashes\n"} 1"#,
+            r#"escaped_values_info{value="{\n  \"ms\": 100\n}",name="test.object"} 1"#,
+            r#"escaped_values_info{value="\"100ms\"",name="test.value"} 1"#,
+            r#"escaped_values_info{value="\\ \\ \\",name="test.backslash"} 1"#,
+        ]
+    } else {
+        [
+            r#"escaped_package_metadata{version="0.1.0",description="Multi-line text\nWith \"quotes\" and \"\\\" slashes\n"} 1"#,
+            r#"escaped_values{value="{\n  \"ms\": 100\n}",name="test.object"} 1"#,
+            r#"escaped_values{value="\"100ms\"",name="test.value"} 1"#,
+            r#"escaped_values{value="\\ \\ \\",name="test.backslash"} 1"#,
+        ]
+    };
+
     for line in expected_lines {
         assert!(lines.contains(&line), "{lines:#?}");
+    }
+}
+
+#[test]
+fn escaping_label_values() {
+    for format in [
+        Format::OpenMetrics,
+        Format::Prometheus,
+        Format::OpenMetricsForPrometheus,
+    ] {
+        println!("format = {format:?}");
+        test_escaping_label_values(format);
     }
 }

--- a/crates/vise/tests/ui/labels/bogus_label_name_in_attr.stderr
+++ b/crates/vise/tests/ui/labels/bogus_label_name_in_attr.stderr
@@ -2,4 +2,4 @@ error[E0080]: evaluation of constant value failed
  --> tests/ui/labels/bogus_label_name_in_attr.rs:4:19
   |
 4 | #[metrics(label = "what?", rename_all = "snake_case")]
-  |                   ^^^^^^^ the evaluated program panicked at 'Label name `what?` is invalid: name contains a disallowed char '?' at position 4; allowed chars are [_a-z0-9]', $DIR/tests/ui/labels/bogus_label_name_in_attr.rs:4:19
+  |                   ^^^^^^^ evaluation panicked: Label name `what?` is invalid: name contains a disallowed char '?' at position 4; allowed chars are [_a-z0-9]

--- a/crates/vise/tests/ui/labels/bogus_label_name_in_field.stderr
+++ b/crates/vise/tests/ui/labels/bogus_label_name_in_field.stderr
@@ -2,4 +2,4 @@ error[E0080]: evaluation of constant value failed
  --> tests/ui/labels/bogus_label_name_in_field.rs:6:5
   |
 6 |     код: u16,
-  |     ^^^ the evaluated program panicked at 'Label name `код` is invalid: name contains non-ASCII chars, first at position 0', $DIR/tests/ui/labels/bogus_label_name_in_field.rs:6:5
+  |     ^^^ evaluation panicked: Label name `код` is invalid: name contains non-ASCII chars, first at position 0

--- a/crates/vise/tests/ui/labels/bogus_label_name_in_metrics_attr.stderr
+++ b/crates/vise/tests/ui/labels/bogus_label_name_in_metrics_attr.stderr
@@ -2,4 +2,4 @@ error[E0080]: evaluation of constant value failed
  --> tests/ui/labels/bogus_label_name_in_metrics_attr.rs:5:24
   |
 5 |     #[metrics(labels = ["methoD"])]
-  |                        ^^^^^^^^^^ the evaluated program panicked at 'Label name `methoD` is invalid: name contains a disallowed char 'D' at position 5; allowed chars are [_a-z0-9]', $DIR/tests/ui/labels/bogus_label_name_in_metrics_attr.rs:5:24
+  |                        ^^^^^^^^^^ evaluation panicked: Label name `methoD` is invalid: name contains a disallowed char 'D' at position 5; allowed chars are [_a-z0-9]

--- a/crates/vise/tests/ui/labels/unimplemented_format.stderr
+++ b/crates/vise/tests/ui/labels/unimplemented_format.stderr
@@ -11,4 +11,3 @@ error[E0277]: `Label` doesn't implement `std::fmt::Display`
   |
   = help: the trait `std::fmt::Display` is not implemented for `Label`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-  = note: this error originates in the macro `$crate::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/vise/tests/ui/metrics/bogus_metric_name.stderr
+++ b/crates/vise/tests/ui/metrics/bogus_metric_name.stderr
@@ -2,4 +2,4 @@ error[E0080]: evaluation of constant value failed
  --> tests/ui/metrics/bogus_metric_name.rs:6:5
   |
 6 |     счетчик: Counter,
-  |     ^^^^^^^ the evaluated program panicked at 'Metric name `счетчик` is invalid: name contains non-ASCII chars, first at position 0', $DIR/tests/ui/metrics/bogus_metric_name.rs:6:5
+  |     ^^^^^^^ evaluation panicked: Metric name `счетчик` is invalid: name contains non-ASCII chars, first at position 0

--- a/crates/vise/tests/ui/metrics/bogus_prefix.stderr
+++ b/crates/vise/tests/ui/metrics/bogus_prefix.stderr
@@ -2,4 +2,4 @@ error[E0080]: evaluation of constant value failed
  --> tests/ui/metrics/bogus_prefix.rs:4:20
   |
 4 | #[metrics(prefix = "what?")]
-  |                    ^^^^^^^ the evaluated program panicked at 'Metric prefix `what?` is invalid: name contains a disallowed char '?' at position 4; allowed chars are [_a-z0-9]', $DIR/tests/ui/metrics/bogus_prefix.rs:4:20
+  |                    ^^^^^^^ evaluation panicked: Metric prefix `what?` is invalid: name contains a disallowed char '?' at position 4; allowed chars are [_a-z0-9]

--- a/crates/vise/tests/ui/metrics/bogus_unit.stderr
+++ b/crates/vise/tests/ui/metrics/bogus_unit.stderr
@@ -14,7 +14,7 @@ help: the type constructed contains `&'static str` due to the type of the argume
   |                 ^^^^^^^
 ...
 6 |     #[metrics(unit = "seconds")]
-  |                      --------- this argument influences the type of `core`
+  |                      --------- this argument influences the type of `Some`
 note: tuple variant defined here
  --> $RUST/core/src/option.rs
   |

--- a/crates/vise/tests/ui/metrics/non_monotonic_buckets.stderr
+++ b/crates/vise/tests/ui/metrics/non_monotonic_buckets.stderr
@@ -2,4 +2,4 @@ error[E0080]: evaluation of constant value failed
  --> tests/ui/metrics/non_monotonic_buckets.rs:3:32
   |
 3 | const BOGUS_BUCKETS: Buckets = Buckets::values(&[0.1, 0.2, 0.1, 0.5]);
-  |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Values must be monotonically increasing; offending value has index 2', $DIR/tests/ui/metrics/non_monotonic_buckets.rs:3:32
+  |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: Values must be monotonically increasing; offending value has index 2

--- a/e2e-tests/src/main.rs
+++ b/e2e-tests/src/main.rs
@@ -20,6 +20,7 @@ enum Method {
 #[derive(Debug, EncodeLabelSet)]
 struct PackageMetadata {
     version: &'static str,
+    description: &'static str,
 }
 
 #[derive(Debug, Metrics)]
@@ -103,7 +104,10 @@ static GROUPED_METRICS: vise::MetricsFamily<Method, MethodMetrics> = vise::Metri
 async fn main() {
     METRICS
         .package_metadata
-        .set(PackageMetadata { version: "0.1.0" })
+        .set(PackageMetadata {
+            version: "0.1.0",
+            description: "Multi-line text\nWith \"quotes\" and \"\\\" slashes\n",
+        })
         .unwrap();
 
     const METRICS_INTERVAL: Duration = Duration::from_secs(5);

--- a/e2e-tests/tests/integration.rs
+++ b/e2e-tests/tests/integration.rs
@@ -305,6 +305,10 @@ async fn assert_metrics(client: &Client, prom_format: bool) -> anyhow::Result<()
         .context("Info data is not a vector")?;
     let info_labels = info_vec[0].metric();
     assert_eq!(info_labels["version"], "0.1.0", "{info_labels:?}");
+    assert_eq!(
+        info_labels["description"], "Multi-line text\nWith \"quotes\" and \"\\\" slashes\n",
+        "{info_labels:?}"
+    );
 
     let gauge_result = client.query("test_gauge_bytes").get().await?;
     tracing::info!(?gauge_result, "Got result for query: test_gauge_bytes");


### PR DESCRIPTION
# What ❔

Escapes `"`, `\n` (LF) and `\` chars in label values.

## Why ❔

The `prometheus-client` library doesn't escape label values as expected by OpenMetrics and Prometheus text formats. This leads to metric reporting getting corrupted if the label value contains any of the 3 chars mentioned above.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.