### PR TITLE
feat: Allow `str` indexing for labeled families

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ keywords = ["metrics", "monitoring", "openmetrics", "prometheus"]
 categories = ["development-tools"]
 
 [workspace.dependencies]
-
 vise-macros = { version = "=0.3.1", path = "crates/vise-macros" }
 vise = { version = "=0.3.1", path = "crates/vise" }
 

--- a/crates/vise-macros/src/labels.rs
+++ b/crates/vise-macros/src/labels.rs
@@ -257,8 +257,8 @@ impl EncodeLabelValueImpl {
         let encode_impl = if let Some(enum_variants) = &self.enum_variants {
             let variant_hands = enum_variants.iter().map(EnumVariant::encode);
             quote! {
-                use core::fmt::Write as _;
-                core::write!(encoder, "{}", match self {
+                use ::core::fmt::Write as _;
+                ::core::write!(encoder, "{}", match self {
                     #(#variant_hands,)*
                 })
             }
@@ -272,8 +272,8 @@ impl EncodeLabelValueImpl {
             };
 
             quote_spanned! {format.span()=>
-                use core::fmt::Write as _;
-                core::write!(encoder, #format, self)
+                use ::core::fmt::Write as _;
+                ::core::write!(encoder, #format, self)
             }
         };
 
@@ -390,7 +390,7 @@ impl LabelField {
         // Skip `Option`al fields by default if they are `None`.
         let default_skip: Path;
         let skip = if self.is_option && self.attrs.skip.is_none() {
-            default_skip = syn::parse_quote_spanned!(span=> core::option::Option::is_none);
+            default_skip = syn::parse_quote_spanned!(span=> ::core::option::Option::is_none);
             Some(&default_skip)
         } else {
             self.attrs.skip.as_ref()
@@ -494,7 +494,7 @@ impl EncodeLabelSetImpl {
             });
             quote! {
                 #(#fields)*
-                core::fmt::Result::Ok(())
+                ::core::fmt::Result::Ok(())
             }
         };
 
@@ -506,7 +506,7 @@ impl EncodeLabelSetImpl {
                 fn encode(
                     &self,
                     encoder: &mut #encoding::LabelSetEncoder<'_>,
-                ) -> core::fmt::Result {
+                ) -> ::core::fmt::Result {
                     #encode_impl
                 }
             }

--- a/crates/vise-macros/src/metrics.rs
+++ b/crates/vise-macros/src/metrics.rs
@@ -190,9 +190,9 @@ impl MetricsField {
         let docs = &self.docs;
 
         let unit = if let Some(unit) = &self.attrs.unit {
-            quote!(core::option::Option::Some(#unit))
+            quote!(::core::option::Option::Some(#unit))
         } else {
-            quote!(core::option::Option::None)
+            quote!(::core::option::Option::None)
         };
 
         quote! {
@@ -219,15 +219,15 @@ impl MetricsField {
         let docs = &self.docs;
         let ty = &self.ty;
         let unit = if let Some(unit) = &self.attrs.unit {
-            quote!(core::option::Option::Some(#unit))
+            quote!(::core::option::Option::Some(#unit))
         } else {
-            quote!(core::option::Option::None)
+            quote!(::core::option::Option::None)
         };
 
         quote! {
             #cr::descriptors::MetricDescriptor {
                 name: #name_str,
-                field_name: core::stringify!(#name),
+                field_name: ::core::stringify!(#name),
                 metric_type: <#ty as #cr::_reexports::TypedMetric>::TYPE,
                 help: #docs,
                 unit: #unit,
@@ -326,11 +326,11 @@ impl MetricsImpl {
 
         let descriptor = quote_spanned! {name.span()=>
             #cr::descriptors::MetricGroupDescriptor {
-                crate_name: core::env!("CARGO_CRATE_NAME"),
-                crate_version: core::env!("CARGO_PKG_VERSION"),
-                module_path: core::module_path!(),
-                name: core::stringify!(#name),
-                line: core::line!(),
+                crate_name: ::core::env!("CARGO_CRATE_NAME"),
+                crate_version: ::core::env!("CARGO_PKG_VERSION"),
+                module_path: ::core::module_path!(),
+                name: ::core::stringify!(#name),
+                line: ::core::line!(),
                 metrics: &[#(#describe_fields,)*],
             }
         };
@@ -351,7 +351,7 @@ impl MetricsImpl {
         let validation = self.validate();
         let initialization = self.initialize();
         let default_impl = quote! {
-            impl core::default::Default for #name {
+            impl ::core::default::Default for #name {
                 fn default() -> Self {
                     #initialization
                 }


### PR DESCRIPTION
# What ❔

Allows indexing by `&str` for `LabeledFamily<String, ..>`.

## Why ❔

This is useful in the Era codebase to avoid `String` allocation and improve DevEx.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.