### PR TITLE
feat: add support for custom registry with labels and prefixes

### DIFF
--- a/crates/vise/src/registry.rs
+++ b/crates/vise/src/registry.rs
@@ -1,6 +1,6 @@
 //! Wrapper around metrics registry.
 
-use std::{collections::HashMap, fmt, sync::Mutex};
+use std::{borrow::Cow, collections::HashMap, fmt, sync::Mutex};
 
 use once_cell::sync::Lazy;
 use prometheus_client::{
@@ -231,6 +231,38 @@ impl Registry {
         }
     }
 
+    /// Creates a new [`Registry`] with the given labels.
+    pub fn with_labels(
+        labels: impl Iterator<Item = (Cow<'static, str>, Cow<'static, str>)>,
+    ) -> Self {
+        Self {
+            descriptors: RegisteredDescriptors::default(),
+            inner: RegistryInner::with_labels(labels),
+            is_lazy: false,
+        }
+    }
+
+    /// Creates a new [`Registry`] with the given prefix and labels.
+    pub fn with_prefix_and_labels(
+        prefix: impl Into<String>,
+        labels: impl Iterator<Item = (Cow<'static, str>, Cow<'static, str>)>,
+    ) -> Self {
+        Self {
+            descriptors: RegisteredDescriptors::default(),
+            inner: RegistryInner::with_prefix_and_labels(prefix, labels),
+            is_lazy: false,
+        }
+    }
+
+    /// Creates a new [`Registry`] with the given prefix.
+    pub fn with_prefix(prefix: impl Into<String>) -> Self {
+        Self {
+            descriptors: RegisteredDescriptors::default(),
+            inner: RegistryInner::with_prefix(prefix),
+            is_lazy: false,
+        }
+    }
+
     /// Returns descriptors for all registered metrics.
     pub fn descriptors(&self) -> &RegisteredDescriptors {
         &self.descriptors
@@ -394,7 +426,7 @@ impl MetricsRegistrations {
         self.inner.lock().unwrap().push(metrics);
     }
 
-    fn get(&self) -> Vec<&'static dyn CollectToRegistry> {
+    pub fn get(&self) -> Vec<&'static dyn CollectToRegistry> {
         self.inner.lock().unwrap().clone()
     }
 }


### PR DESCRIPTION
First of all, thanks a lot for creating this library! We use it in Nethermind for metrics in one project (in private repo, but it will be published in a few weeks). 

# What ❔

This PR adds `with_prefix` and `with_labels` functions to `MetricsCollection` to allow adding global labels and prefix to all metrics. It also changes the visibility of `get` method in `MetricsRegistrations` to allow registering metrics for user-defined registries. 

## Why ❔

For the time being, vise was providing everything needed for our purposes, the only thing we found missing is the ability to add global labels and prefixes to all metrics. These changes allow developer to set those by creating a custom registry with needed labels and then accessing `METRICS_REGISTRATIONS` to register all metrics.

## Example

Example of usage:

```rust
    let name = String::from("peerinfo");
    let exporter = MetricsExporter::new(
        MetricsCollection::default()
            .with_prefix("app_peerinfo")
            .with_labels([("peer", name)])
            .collect()
            .into(),
    )
    .bind(bind_address)
    .await
    .expect("Failed to bind metrics exporter");
```

### Possible enhancement

This PR provides minimal changes needed to allow developers adding labels and prefixes for the metrics. A possible continuation of this PR would be adding something like `LabeledMetricsCollection` struct that will work in the same way as `MetricsCollection` and it will improve dev experience much more. But I want to keep this PR minimalistic.

#### Upd:

- As was proposed in comment, moved `with_prefix` and `with_labels` functions from `Registry` to `MetricsCollection` and removed `with_prefix_and_labels` function from `Registry`

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.
