### PR TITLE
fix: pin toolchain for trybuild UI tests to stop diagnostic drift and bump package versions to fix failing cargo deny

### DIFF
--- a/.github/workflows/cargo-license.yaml
+++ b/.github/workflows/cargo-license.yaml
@@ -6,5 +6,6 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@v4
-    - uses: EmbarkStudios/cargo-deny-action@76cd80eb775d7bbbd2d80292136d74d39e1b4918 # v2.0.14
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+      - run: rm Cargo.lock
+      - uses: EmbarkStudios/cargo-deny-action@76cd80eb775d7bbbd2d80292136d74d39e1b4918 # v2.0.14

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,10 @@ env:
   msrv: 1.79.0
   # Nightly Rust necessary for building docs.
   nightly: nightly-2025-05-23
+  # Pinned toolchain for UI (trybuild) tests. Their expected output is tied to the exact `rustc`
+  # diagnostics, which change between releases, so these tests must run on a fixed version. Bump
+  # this together with the `*.stderr` snapshots under `crates/vise/tests/ui/`.
+  ui_toolchain: 1.97.0
 
 jobs:
   build-msrv:
@@ -64,6 +68,28 @@ jobs:
         run: cargo test -p vise-exporter --no-default-features --all-targets
       - name: Run doc tests
         run: cargo test --workspace --all-features --doc
+
+  # UI (trybuild) tests are gated behind `VISE_UI_TESTS` and pinned to a single toolchain because
+  # their expected output depends on exact `rustc` diagnostics, which drift across releases. The
+  # regular `build` job runs on `stable` and therefore skips them.
+  ui-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.ui_toolchain }}
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Run UI tests
+        env:
+          VISE_UI_TESTS: "1"
+        run: cargo test -p vise --test integration
 
   build-nightly:
     needs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,6 +95,7 @@ jobs:
     needs:
       - build
       - build-msrv
+      - ui-tests
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   pull_request:
-    branches: [ "*" ]
+    branches: ["*"]
   push:
     branches: ["main"]
 
@@ -26,14 +26,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.msrv }}
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # mozilla-actions/sccache-action@v0.0.9
 
       - name: Build libraries
         run: cargo build --workspace --exclude vise-e2e-tests --lib --all-features
@@ -45,15 +45,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           components: rustfmt, clippy, rust-src
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # mozilla-actions/sccache-action@v0.0.9
 
       - name: Format
         run: cargo fmt --all -- --config imports_granularity=Crate --config group_imports=StdExternalCrate --check
@@ -77,14 +77,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.ui_toolchain }}
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # mozilla-actions/sccache-action@v0.0.9
 
       - name: Run UI tests
         env:
@@ -100,14 +100,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.nightly }}
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # mozilla-actions/sccache-action@v0.0.9
 
       - name: Build libraries
         run: cargo build --workspace --exclude vise-e2e-tests --lib --all-features
@@ -120,7 +120,7 @@ jobs:
           cargo rustdoc -p vise-exporter --all-features -- -D warnings --cfg docsrs
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # JamesIves/github-pages-deploy-action@v4
         if: github.event_name == 'push' && github.ref_type == 'branch'
         with:
           branch: gh-pages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert_matches"
@@ -49,9 +49,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -112,11 +112,10 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -665,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "once_cell"
@@ -880,9 +879,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1264,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1278,15 +1277,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",

--- a/crates/vise/tests/integration.rs
+++ b/crates/vise/tests/integration.rs
@@ -1,7 +1,26 @@
 //! Integration tests for `vise` library.
 
+/// UI tests assert on the exact text of `rustc` diagnostics, which is **not** stable across
+/// compiler releases. Running them on an arbitrary toolchain produces spurious mismatches, so
+/// they are opt-in: they only run when `VISE_UI_TESTS` is set in the environment. CI runs them
+/// under a single pinned toolchain (see the `ui-tests` job in `.github/workflows/rust.yml`).
+///
+/// To refresh the expected `*.stderr` snapshots after an intentional change, run with the same
+/// pinned toolchain that CI uses:
+///
+/// ```bash
+/// VISE_UI_TESTS=1 TRYBUILD=overwrite cargo +<pinned-version> test -p vise --test integration
+/// ```
 #[test]
 fn ui() {
+    if std::env::var_os("VISE_UI_TESTS").is_none() {
+        eprintln!(
+            "skipping UI tests; set `VISE_UI_TESTS=1` to run them (only reliable on the pinned \
+             toolchain, see `.github/workflows/rust.yml`)"
+        );
+        return;
+    }
+
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/metrics/*.rs");
     t.compile_fail("tests/ui/labels/*.rs");

--- a/crates/vise/tests/ui/labels/bogus_field_type.stderr
+++ b/crates/vise/tests/ui/labels/bogus_field_type.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `Vec<String>: EncodeLabelValue` is not satisfied
+error[E0277]: the trait bound `Vec<String>: vise::_reexports::encoding::EncodeLabelValue` is not satisfied
  --> tests/ui/labels/bogus_field_type.rs:5:5
   |
 5 |     method: Vec<String>,
-  |     ^^^^^^ the trait `EncodeLabelValue` is not implemented for `Vec<String>`
+  |     ^^^^^^ the trait `vise::_reexports::encoding::EncodeLabelValue` is not implemented for `Vec<String>`
   |
-  = help: the following other types implement trait `EncodeLabelValue`:
+  = help: the following other types implement trait `vise::_reexports::encoding::EncodeLabelValue`:
             &String
             &str
             Arc<T>

--- a/crates/vise/tests/ui/labels/unimplemented_format.stderr
+++ b/crates/vise/tests/ui/labels/unimplemented_format.stderr
@@ -14,4 +14,3 @@ help: the trait `std::fmt::Display` is not implemented for `Label`
   | ^^^^^^^^^^
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
   = note: required for `&Label` to implement `std::fmt::Display`
-  = note: this error originates in the macro `$crate::format_args` which comes from the expansion of the macro `::core::write` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/vise/tests/ui/metrics/bogus_buckets.stderr
+++ b/crates/vise/tests/ui/metrics/bogus_buckets.stderr
@@ -6,8 +6,12 @@ error[E0277]: the trait bound `Buckets: From<&str>` is not satisfied
 7 |     histogram: Histogram<u64>,
   |                --------- required by a bound introduced by this call
   |
-  = help: the trait `From<&str>` is not implemented for `Buckets`
-          but trait `From<&'static [f64; _]>` is implemented for it
+help: the trait `From<&str>` is not implemented for `Buckets`
+      but trait `From<&'static [f64; _]>` is implemented for it
+ --> src/buckets.rs
+  |
+  | impl<const N: usize> From<&'static [f64; N]> for Buckets {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = help: for that trait implementation, expected `[f64; _]`, found `str`
   = note: required for `&str` to implement `Into<Buckets>`
 note: required by a bound in `MetricBuilder::<(), L>::with_buckets`

--- a/crates/vise/tests/ui/metrics/bogus_unit.stderr
+++ b/crates/vise/tests/ui/metrics/bogus_unit.stderr
@@ -17,7 +17,4 @@ help: the type constructed contains `&'static str` due to the type of the argume
   |                      --------- this argument influences the type of `Some`
 note: tuple variant defined here
  --> $RUST/core/src/option.rs
-  |
-  |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
-  |     ^^^^
   = note: this error originates in the derive macro `Metrics` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/deny.toml
+++ b/deny.toml
@@ -28,3 +28,6 @@ skip = [
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+
+[graph]
+exclude-dev = true

--- a/deny.toml
+++ b/deny.toml
@@ -28,6 +28,3 @@ skip = [
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-
-[graph]
-exclude-dev = true


### PR DESCRIPTION
# What ❔

- bump minor package versions to fix failing cargo deny check
- gate `ui()` behind the `VISE_UI_TESTS` env var so the regular `build` job (on `stable`) and local `cargo test` skip it instead of failing
- add a dedicated `ui-tests` CI job pinned to `ui_toolchain` (1.97.0 - latest stable) that sets the flag and runs the suite
- re-bless the `*.stderr` snapshots against 1.97.0
- delete `Cargo.lock` file after checkout in Cargo License Check CI

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.
