### PR TITLE
ci(release-please): bump reusable CI version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,10 +16,13 @@ on:
 jobs:
 
   release:
-    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@c3b31c6f11bada204069c8b4621044e4c1cbc1df
+    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@fcfe16cdf551d9a6b99d9e28d4c705faf0f4c27e
     secrets:
-      gh_token: ${{ secrets.RELEASE_TOKEN }}
       slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}
+      # Org-level secrets of the GitHub App used to mint installation tokens.
+      # API commits are auto-signed.
+      MATTERLABS_BOTS_APP_ID: ${{ secrets.MATTERLABS_BOTS_APP_ID }}
+      MATTERLABS_BOTS_PRIVATE_KEY: ${{ secrets.MATTERLABS_BOTS_PRIVATE_KEY }}
     with:
       config: '.github/release-please/config.json'     # Specify the path to the configuration file
       manifest: '.github/release-please/manifest.json' # Specify the path to the manifest file


### PR DESCRIPTION
# What ❔

- bump version of reusable release-please workflow to support commit signing

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.
